### PR TITLE
refactor(module2): restructure OCP module required path to ~40 min

### DIFF
--- a/content/antora.yml
+++ b/content/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     # page-toclevels: -1               # <- This will remove the TOC that appear in the right sidebar at wider resolutions
     page-pagination: true
     workshop-title: "LB2865: Container Hardening: Zero to Hero with Red Hat Hardened Images"
-    workshop-duration: '75 minutes'
+    workshop-duration: '90 minutes'
 
     weblab-duration: '15 minutes'
     # Module 1 - Developer Environment
@@ -27,7 +27,7 @@ asciidoc:
     grype-version: 'v0.109.1'
 
     # Module 2 - Platform Engineering
-    lab2-duration: '30 minutes'
+    lab2-duration: '40 minutes'
     lab2-audience: 'Platform Engineers / DevOps (Intermediate to Advanced)'
     openshift-version: '4.21'
     shipwright-operator: 'Builds for Red Hat OpenShift'

--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -11,9 +11,6 @@
 * Module 2: Shipwright and Buildpacks (OpenShift)
 ** xref:module-02-01-buildpacks.adoc[2.1: Building with Hummingbird]
 ** xref:module-02-07-acs-zero-cve.adoc[2.2: Zero-CVE with ACS Enforcement]
-** xref:module-02-02-custom-strategies.adoc[2.3: Custom Multi-Language Strategies (Optional)]
-** xref:module-02-03-security-pipeline.adoc[2.4: Security Pipeline & Production (Optional)]
-** xref:module-02-04-tekton-udica.adoc[2.5: SELinux Policy CI/CD with Tekton (Optional)]
 
 * Appendix: Environment Setup
 ** xref:appendix-a-rhel-setup.adoc[Appendix A: RHEL Developer Environment]

--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -10,10 +10,10 @@
 
 * Module 2: Shipwright and Buildpacks (OpenShift)
 ** xref:module-02-01-buildpacks.adoc[2.1: Building with Hummingbird]
-** xref:module-02-02-custom-strategies.adoc[2.2: Custom Multi-Language Strategies]
-** xref:module-02-03-security-pipeline.adoc[2.3: Security Pipeline & Production]
-** xref:module-02-04-tekton-udica.adoc[2.4: SELinux Policy CI/CD with Tekton]
-** xref:module-02-07-acs-zero-cve.adoc[2.5: Zero-CVE with ACS Enforcement]
+** xref:module-02-07-acs-zero-cve.adoc[2.2: Zero-CVE with ACS Enforcement]
+** xref:module-02-02-custom-strategies.adoc[2.3: Custom Multi-Language Strategies (Optional)]
+** xref:module-02-03-security-pipeline.adoc[2.4: Security Pipeline & Production (Optional)]
+** xref:module-02-04-tekton-udica.adoc[2.5: SELinux Policy CI/CD with Tekton (Optional)]
 
 * Appendix: Environment Setup
 ** xref:appendix-a-rhel-setup.adoc[Appendix A: RHEL Developer Environment]

--- a/content/modules/ROOT/pages/appendix-b-openshift-setup.adoc
+++ b/content/modules/ROOT/pages/appendix-b-openshift-setup.adoc
@@ -15,7 +15,7 @@
 * {shipwright-operator} operator installed
 * OpenShift Data Foundation (ODF) operator installed (provides S3 object storage for Quay via NooBaa)
 * Red Hat Quay operator installed (on-cluster registry with Clair, ODF-backed storage)
-* Red Hat Advanced Cluster Security (ACS) operator installed (for Sub-Module 2.7)
+* Red Hat Advanced Cluster Security (ACS) operator installed (for Sub-Module 2.2)
 * Red Hat Trusted Artifact Signer (RHTAS) operator installed (for Sub-Module 2.6)
 * Keycloak `trusted-artifact-signer` realm configured for RHTAS OIDC
 * RHTAS CLI tools (`cosign`, `rekor-cli`, `ec`) installed
@@ -619,10 +619,10 @@ quay-registry-clair-app-...                   1/1     Running   0          ...
 
 [NOTE]
 ====
-This section is only required if you plan to complete **xref:module-02-07-acs-zero-cve.adoc[Sub-Module 2.7: The Immutable Fortress -- Zero-CVE with ACS Enforcement]**. You can skip it for all other Module 2 labs.
+This section is only required if you plan to complete **xref:module-02-07-acs-zero-cve.adoc[Sub-Module 2.2: The Immutable Fortress -- Zero-CVE with ACS Enforcement]**. You can skip it for all other Module 2 labs.
 ====
 
-Red Hat Advanced Cluster Security for Kubernetes (RHACS) provides vulnerability scanning, policy enforcement, and admission control. Sub-Module 2.7 uses ACS to enforce a zero-CVE posture on the cluster.
+Red Hat Advanced Cluster Security for Kubernetes (RHACS) provides vulnerability scanning, policy enforcement, and admission control. Sub-Module 2.2 uses ACS to enforce a zero-CVE posture on the cluster.
 
 [NOTE]
 ====
@@ -823,7 +823,7 @@ stackrox-validating-webhook  1          ...
 If the webhook does not appear, check that `listenOnCreates` is set to `true` in the SecuredCluster spec and that the admission controller pod is running.
 ====
 
-Your ACS installation is ready. Proceed to xref:module-02-07-acs-zero-cve.adoc[Sub-Module 2.7: The Immutable Fortress].
+Your ACS installation is ready. Proceed to xref:module-02-07-acs-zero-cve.adoc[Sub-Module 2.2: The Immutable Fortress].
 
 [[rhtas-setup]]
 === Red Hat Trusted Artifact Signer (RHTAS) Setup

--- a/content/modules/ROOT/pages/module-02-01-buildpacks.adoc
+++ b/content/modules/ROOT/pages/module-02-01-buildpacks.adoc
@@ -503,11 +503,20 @@ Congratulations! You've built and deployed your first Hummingbird application on
 
 === Next Sub-Module
 
-Ready for advanced strategies? Proceed to:
+Ready to enforce zero-CVE at the cluster level? Proceed to:
 
-**xref:module-02-02-custom-strategies.adoc[Sub-Module 2.2: Custom Multi-Language Strategies]**
+**xref:module-02-07-acs-zero-cve.adoc[Sub-Module 2.2: Zero-CVE with ACS Enforcement]**
 
-Create a ClusterBuildStrategy with language auto-detection, conditional Hummingbird runtime selection, and integration with internal registries.
+Deploy a legacy image, scan it with ACS to expose CVEs, then rewrite it using a Hummingbird distroless build and enforce a zero-CVE admission policy.
+
+[TIP]
+====
+Looking for additional depth? The following optional sub-modules extend the workshop with advanced topics:
+
+* xref:module-02-02-custom-strategies.adoc[Sub-Module 2.3: Custom Multi-Language Strategies (Optional)]
+* xref:module-02-03-security-pipeline.adoc[Sub-Module 2.4: Security Pipeline & Production (Optional)]
+* xref:module-02-04-tekton-udica.adoc[Sub-Module 2.5: SELinux Policy CI/CD with Tekton (Optional)]
+====
 
 === Additional Resources
 

--- a/content/modules/ROOT/pages/module-02-02-custom-strategies.adoc
+++ b/content/modules/ROOT/pages/module-02-02-custom-strategies.adoc
@@ -5,6 +5,7 @@
 --
 *Duration:* ~12 minutes +
 *Prerequisites:* Completion of Sub-Module 2.1 (Building with Hummingbird) +
+*Status:* Optional exercise -- not required for Module 2 completion +
 *Learning Objectives:*
 
 * Create ClusterBuildStrategy with language auto-detection

--- a/content/modules/ROOT/pages/module-02-03-security-pipeline.adoc
+++ b/content/modules/ROOT/pages/module-02-03-security-pipeline.adoc
@@ -5,6 +5,7 @@
 --
 *Duration:* ~13 minutes +
 *Prerequisites:* Completion of Sub-Module 2.2 (Custom Multi-Language Strategies) +
+*Status:* Optional exercise -- not required for Module 2 completion +
 *Learning Objectives:*
 
 * Integrate SBOM generation into BuildStrategy

--- a/content/modules/ROOT/pages/module-02-04-tekton-udica.adoc
+++ b/content/modules/ROOT/pages/module-02-04-tekton-udica.adoc
@@ -5,6 +5,7 @@
 --
 *Duration:* ~8 minutes +
 *Prerequisites:* Completion of Sub-Module 2.3 (Security Pipeline) and familiarity with Module 1 SELinux concepts +
+*Status:* Optional exercise -- not required for Module 2 completion +
 *Learning Objectives:*
 
 * Create a Tekton Task that generates udica SELinux policies from container images
@@ -566,7 +567,7 @@ Congratulations! You've completed Sub-Module 2.4.
 
 Continue to the final required exercise:
 
-**xref:module-02-07-acs-zero-cve.adoc[Sub-Module 2.5: The Immutable Fortress -- Zero-CVE with ACS Enforcement]**
+**xref:module-02-07-acs-zero-cve.adoc[Sub-Module 2.2: The Immutable Fortress -- Zero-CVE with ACS Enforcement]**
 
 Prove the zero-CVE posture by deploying a legacy vulnerable image alongside a Hummingbird image, then enforce admission control policies with Red Hat Advanced Cluster Security (~25 min).
 

--- a/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
+++ b/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
@@ -1,10 +1,10 @@
-= Sub-Module 2.5: The Immutable Fortress -- Zero-CVE with ACS Enforcement
+= Sub-Module 2.2: The Immutable Fortress -- Zero-CVE with ACS Enforcement
 
 .*Sub-Module Overview*
 [sidebar]
 --
 *Duration:* ~25 minutes +
-*Prerequisites:* Completion of Sub-Module 2.4 (SELinux Policy CI/CD); ACS installed per xref:appendix-b-openshift-setup.adoc[Appendix B] +
+*Prerequisites:* Completion of Sub-Module 2.1 (Building with Hummingbird); ACS installed per xref:appendix-b-openshift-setup.adoc[Appendix B] +
 *Target Audience:* Application Developers, DevSecOps Engineers, CI/CD Architects +
 *Learning Objectives:*
 
@@ -1462,7 +1462,7 @@ done
 [[summary]]
 == Summary
 
-Congratulations! You have completed Sub-Module 2.7 -- The Immutable Fortress.
+Congratulations! You have completed Sub-Module 2.2 -- The Immutable Fortress.
 
 .*What You Accomplished*
 {empty} +


### PR DESCRIPTION
## Summary

- Promotes ACS Zero-CVE (previously sub-module 2.5/2.7) to Sub-Module 2.2 — the second required exercise, immediately after Buildpacks (2.1)
- Marks Custom Multi-Language Strategies, Security Pipeline & Production, and SELinux Policy CI/CD with Tekton as optional (removed from sidebar nav, Status markers added to each module's sidebar block)
- Updates lab2-duration from 30 minutes → 40 minutes and workshop-duration from 75 minutes → 90 minutes in antora.yml
- Updates all cross-references, prerequisites text, end-of-module next links, and appendix labels to reflect the new sub-module numbering

## Why

The OCP module content had grown significantly beyond its stated 30-minute duration. The required path (2.1 Buildpacks + 2.2 ACS) now totals ~40 min, bringing the workshop to a realistic 90-minute total (15 min web + 30 min RHEL + 40 min OCP), with optional depth content available for attendees who finish early.

## Test plan
- [ ] Verify nav sidebar shows only 2.1 and 2.2 for Module 2
- [ ] Verify workshop index page shows Total Time: 90 min, OCP Module: 40 min
- [ ] Verify Sub-Module 2.2 (ACS) header and prerequisites are correct
- [ ] Verify optional modules show Status: Optional in their sidebar blocks
- [ ] Verify end-of-module link in 2.1 (Buildpacks) points to 2.2 (ACS)