### PR TITLE
feat: add solver and validator for module-01 and module-02

### DIFF
--- a/content/lib/inject-buttons.js
+++ b/content/lib/inject-buttons.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+
+// Antora extension: inline buttons.js and site-extra.css into every page.
+// Reads the files directly at build time — no CDN, no caching issues.
+
+module.exports.register = function () {
+  this.on('pagesComposed', ({ contentCatalog }) => {
+    const pages = contentCatalog.getPages().filter((p) => p.contents && p.out)
+    console.log(`[inject-buttons] pagesComposed — inlining into ${pages.length} pages`)
+
+    // Read files relative to this extension's location
+    const base = path.resolve(__dirname, '..', 'supplemental-ui')
+    const css  = fs.readFileSync(path.join(base, 'css', 'site-extra.css'), 'utf8')
+    const js   = fs.readFileSync(path.join(base, 'js', 'buttons.js'), 'utf8')
+
+    const INJECT = `<style>\n${css}\n</style>\n<script>\n${js}\n</script>`
+
+    pages.forEach((page) => {
+      const html = page.contents.toString()
+      if (html.includes('stream-panel') || html.includes('solve-btn')) return
+      const updated = html.replace('</body>', INJECT + '\n</body>')
+      if (updated !== html) page.contents = Buffer.from(updated)
+    })
+  })
+}

--- a/content/supplemental-ui/css/site-extra.css
+++ b/content/supplemental-ui/css/site-extra.css
@@ -32,4 +32,125 @@ video {
 .navbar-item-right-content {
     width: 100%;
     background-color: #131313;
+}/* left align items inside imageblock */
+.doc .imageblock {
+    align-items: flex-start;
+  }
+
+/* add a shadow to the image container */
+.doc .bordershadow .content{
+    border: solid 1px black;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 }
+
+/*custom video css*/
+video {
+    border: solid 1px black;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}
+
+/* allow for wider screens */
+.doc {
+    max-width: none;
+}
+
+.navbar-item-right-dropdown {
+    float: right!important;
+}
+
+.navbar-dropdown-right {
+    right: 0;
+    left: auto;
+}
+
+.navbar-item-right-content {
+    width: 100%;
+    background-color: #131313;
+}
+
+/* ── Live stream panel ──────────────────────────────── */
+.stream-panel {
+  margin-top: 1rem; border: 1px solid #dee2e6; border-radius: 8px;
+  overflow: hidden; animation: slideDown 0.2s ease;
+}
+@keyframes slideDown { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }
+
+.stream-status {
+  padding: 0.6rem 1rem; background: #f0f0f0;
+  border-bottom: 1px solid #dee2e6; font-weight: 600; font-size: 0.95rem;
+}
+.sp-spinner { color: #666; }
+.sp-status-pass { color: #155724; }
+.sp-status-fail { color: #721c24; }
+
+.stream-steps {
+  padding: 0.75rem 1rem; background: #fafafa;
+  border-bottom: 1px solid #dee2e6;
+}
+.sp-steps-label {
+  font-size: 0.72rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.06em; color: #888; margin-bottom: 0.5rem;
+}
+
+.sp-step-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.3rem; }
+.sp-step {
+  padding: 0.25rem 0.6rem; border-radius: 4px; font-size: 0.84rem;
+  font-family: 'Courier New', monospace;
+}
+.sp-step-pending { background: #fff3cd; color: #856404; }
+.sp-step-ok      { background: #d4edda; color: #155724; }
+.sp-step-changed { background: #d1ecf1; color: #0c5460; }
+.sp-step-fail    { background: #f8d7da; color: #721c24; }
+
+/* ── Collapsible log toggle ──────────────────────────── */
+.stream-logs-wrap { border-top: 1px solid #222; }
+.sp-logs-toggle {
+  display: block; padding: 0.5rem 1rem;
+  background: #1a1a1a; color: #888;
+  font-size: 0.78rem; cursor: pointer;
+  user-select: none; list-style: none;
+}
+.sp-logs-toggle:hover { color: #00ff00; }
+.stream-logs-wrap[open] .sp-logs-toggle { color: #00cc44; }
+.sp-log-content {
+  margin: 0; background: #020408; color: #4ade80;
+  font-family: 'Courier New', monospace; font-size: 0.76rem;
+  line-height: 1.5; white-space: pre-wrap; word-break: break-all;
+  max-height: 260px; overflow-y: auto;
+  padding: 0.75rem 1rem;
+}
+
+/* ── Send-to button ─────────────────────────────────── */
+.listingblock { position: relative; }
+.send-to-command-btn {
+  position: absolute; top: 0.5rem; right: 0.5rem;
+  background: #28a745; color: white; border: none; border-radius: 4px;
+  padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600;
+  cursor: pointer; transition: all 0.2s; z-index: 100;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2); opacity: 0.3;
+}
+.send-to-command-btn:hover { background: #218838; transform: translateY(-2px); opacity: 1; }
+.send-to-command-btn.success { background: #27ae60; }
+.send-to-command-btn.copied { background: #3498db; }
+.listingblock pre.send-to { padding-top: 3rem !important; }
+
+/* ── Solve / Validate shared ────────────────────────── */
+.btn-section { margin: 2rem 0; padding: 1.5rem; background: #f8f9fa; border: 2px solid #dee2e6; border-radius: 8px; }
+.btn-controls { margin-bottom: 1rem; }
+.btn-output { margin-top: 1rem; background-color: #000 !important; border-radius: 6px; padding: 1.5rem; max-height: 600px; overflow-y: auto; }
+.btn-output-content { margin: 0 !important; padding: 0 !important; background: transparent !important; font-family: 'Courier New', monospace; font-size: 14px; line-height: 1.8; white-space: pre-wrap; word-wrap: break-word; font-weight: 500; }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+
+/* ── Solve button ───────────────────────────────────── */
+.solve-btn { padding: 0.75rem 1.5rem; font-size: 1rem; font-weight: 600; border: none; border-radius: 6px; cursor: pointer; transition: all 0.3s ease; background: #28a745; color: white; }
+.solve-btn:hover:not(:disabled) { background: #218838; transform: translateY(-2px); box-shadow: 0 4px 8px rgba(40,167,69,0.3); }
+.solve-btn:disabled { background: #adb5bd; cursor: not-allowed; animation: pulse 1.5s ease-in-out infinite; }
+.btn-output:has(.solve-btn) { border: 2px solid #00ff00; box-shadow: 0 0 10px rgba(0,255,0,0.2); }
+#solve-output-content { color: #00ff00 !important; }
+[id^="solve-output-content"] { color: #00ff00 !important; }
+
+/* ── Validate button ────────────────────────────────── */
+.validate-btn { padding: 0.75rem 1.5rem; font-size: 1rem; font-weight: 600; border: none; border-radius: 6px; cursor: pointer; transition: all 0.3s ease; background: #007bff; color: white; }
+.validate-btn:hover:not(:disabled) { background: #0056b3; transform: translateY(-2px); box-shadow: 0 4px 8px rgba(0,123,255,0.3); }
+.validate-btn:disabled { background: #adb5bd; cursor: not-allowed; animation: pulse 1.5s ease-in-out infinite; }
+[id^="validate-output-content"] { color: #00bfff !important; }

--- a/content/supplemental-ui/js/buttons.js
+++ b/content/supplemental-ui/js/buttons.js
@@ -1,0 +1,348 @@
+(function () {
+  'use strict';
+
+  // ── Send-to Terminal ──────────────────────────────────────────────────────
+  // Role name maps directly to URL path in the terminal iframe src.
+  // Alerts if the matching iframe is not found.
+  //
+  //   role="send-to-wetty"    → looks for iframe with /wetty in src (bastion)
+  //   role="send-to-terminal" → looks for iframe with /terminal in src (node)
+  //
+  // The path after "send-to-" must match the terminal URL in ui-config.yml.
+  // Combine with execute for the theme copy button alongside ▶:
+  //   role="execute send-to-wetty"
+
+  function initSendTo() {
+    // Find all elements whose class list contains a class starting with 'send-to-'
+    document.querySelectorAll('[class*="send-to-"]').forEach(function (block) {
+      if (block.dataset.sendToButtonAdded) return;
+      var listingBlock = block.closest('.listingblock');
+      if (!listingBlock) return;
+
+      // Extract the target path from the class name e.g. 'send-to-wetty' → '/wetty'
+      var targetClass = Array.from(block.classList).find(function (c) { return /^send-to-.+/.test(c); });
+      if (!targetClass) return;
+      var targetPath = '/' + targetClass.replace('send-to-', '');
+
+      var btn = document.createElement('button');
+      btn.className = 'send-to-command-btn';
+      btn.title = 'Send to ' + targetPath;
+      btn.innerHTML = '▶';
+      btn.onclick = function () {
+        var cmd = (block.querySelector('code') || block).textContent.trim();
+        sendToTerminal(cmd, btn, targetPath);
+      };
+      listingBlock.appendChild(btn);
+      block.dataset.sendToButtonAdded = 'true';
+    });
+  }
+
+  function findFrame(targetPath) {
+    try {
+      if (!window.parent || window.parent === window) return null;
+      var frames = window.parent.document.querySelectorAll('iframe');
+      for (var i = 0; i < frames.length; i++) {
+        if ((frames[i].src || '').indexOf(targetPath) !== -1) return frames[i];
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  function sendToTerminal(command, button, targetPath) {
+    var frame = findFrame(targetPath);
+    var original = button.innerHTML;
+    if (!frame) {
+      alert('Cannot find terminal at ' + targetPath + ' in this showroom.\nCheck ui-config.yml has a tab with ' + targetPath + ' URL.');
+      return;
+    }
+
+    // Inject execute-listener into terminal if not already done
+    // Only inject for /terminal, not for /wetty (which has native support)
+    if (targetPath === '/terminal') {
+      ensureTerminalListener(frame);
+    }
+
+    frame.contentWindow.postMessage({ type: 'execute', data: command + '\r' }, '*');
+    button.classList.add('success'); button.innerHTML = '✓ Sent!';
+    setTimeout(function () { button.classList.remove('success'); button.innerHTML = original; }, 2000);
+  }
+
+  function ensureTerminalListener(frame) {
+    if (frame.dataset.listenerInjected) return;
+
+    var listenerScript = `
+(function() {
+  if (window.__terminalListenerInstalled) return;
+  window.__terminalListenerInstalled = true;
+
+  window.addEventListener("message", function(event) {
+    if (event.data && event.data.type === "execute") {
+      var command = event.data.data;
+      var term = window.term;
+
+      if (term) {
+        command = command.replace(/[\\r\\n]+$/, "");
+
+        // Method 1: Try terminal client object (most reliable)
+        if (window.client && typeof window.client.sendData === 'function') {
+          window.client.sendData(command + '\\r');
+          return;
+        }
+
+        // Method 2: Simulate keyboard input using xterm.js internal API
+        if (term._core && term._core.coreService && term._core.coreService._inputHandler) {
+          for (var i = 0; i < command.length; i++) {
+            term._core.coreService._inputHandler.parse(command[i]);
+          }
+          term._core.coreService._inputHandler.parse('\\r');
+          return;
+        }
+
+        // Method 3: Try accessing onData handler through _core
+        if (term._core && term._core._onData) {
+          term._core._onData.fire(command + '\\r');
+          return;
+        }
+
+        // Method 4: Fallback - write to display only (won't execute)
+        term.write(command + '\\r\\n');
+      }
+    }
+  }, false);
+})();`;
+
+    try {
+      var script = frame.contentWindow.document.createElement('script');
+      script.textContent = listenerScript;
+      frame.contentWindow.document.body.appendChild(script);
+      frame.dataset.listenerInjected = 'true';
+    } catch (e) {
+      console.error('Failed to inject terminal listener:', e);
+    }
+  }
+
+  // ── Solve / Validate buttons ──────────────────────────────────────────────
+
+  function initSolve() {
+    document.querySelectorAll('.solve-button-placeholder').forEach(function (p) {
+      var m = p.getAttribute('data-module');
+      var wrap = document.createElement('div');
+      wrap.className = 'btn-section';
+      wrap.innerHTML = '<button class="solve-btn" data-module="' + m + '">🚀 Solve Module</button>';
+      p.replaceWith(wrap);
+    });
+    document.querySelectorAll('.solve-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () { runStream('solve', this.getAttribute('data-module'), this.closest('.btn-section')); });
+    });
+  }
+
+  function initValidate() {
+    document.querySelectorAll('.validate-button-placeholder').forEach(function (p) {
+      var m = p.getAttribute('data-module');
+      var wrap = document.createElement('div');
+      wrap.className = 'btn-section';
+      wrap.innerHTML = '<button class="validate-btn" data-module="' + m + '">✓ Validate Module</button>';
+      p.replaceWith(wrap);
+    });
+    document.querySelectorAll('.validate-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () { runStream('validate', this.getAttribute('data-module'), this.closest('.btn-section')); });
+    });
+  }
+
+  // ── Live panel ────────────────────────────────────────────────────────────
+
+  function runStream(stage, moduleName, section) {
+    var btn = section.querySelector('.' + stage + '-btn');
+    var label = stage === 'solve' ? '🚀 Solve Module' : '✓ Validate Module';
+
+    // Remove existing panel if re-running
+    var old = section.querySelector('.stream-panel');
+    if (old) old.remove();
+
+    // Create live panel — no IDs, use querySelector on the panel itself
+    var panel = document.createElement('div');
+    panel.className = 'stream-panel';
+    panel.innerHTML =
+      '<div class="stream-status">' +
+        '<span class="sp-spinner">Running...</span>' +
+      '</div>' +
+      '<div class="stream-steps">' +
+        '<div class="sp-steps-label">Steps</div>' +
+        '<ul class="sp-step-list"></ul>' +
+      '</div>' +
+      '<details class="stream-logs-wrap">' +
+        '<summary class="sp-logs-toggle">Show logs</summary>' +
+        '<pre class="sp-log-content"></pre>' +
+      '</details>';
+    section.appendChild(panel);
+
+    btn.disabled = true;
+    btn.textContent = '⏳ Running...';
+
+    // Reference elements directly from panel — no getElementById, no duplicate ID issues
+    var statusEl  = panel.querySelector('.stream-status');
+    var stepList  = panel.querySelector('.sp-step-list');
+    var logEl     = panel.querySelector('.sp-log-content');
+
+    // State for solve step tracking
+    var currentTask = null;
+    var pendingLi   = null;
+
+    var es = new EventSource('/stream/' + stage + '/' + moduleName);
+
+    es.onmessage = function (event) {
+      if (event.data === '__DONE__') {
+        es.close();
+        btn.disabled = false;
+        btn.textContent = label;
+        finalize(stage, statusEl, stepList, logEl);
+        return;
+      }
+
+      var line = '';
+      try { line = JSON.parse(event.data); } catch (x) { line = event.data; }
+
+      // ── Append to full log ──
+      logEl.textContent += line;
+      logEl.scrollTop = logEl.scrollHeight;
+
+      // ── Update steps live ──
+      // Parse TASK names → step chips
+      parseSolveLine(line, stepList, { currentTask: currentTask, pendingLi: pendingLi },
+        function (state) { currentTask = state.currentTask; pendingLi = state.pendingLi; });
+      // Parse validation_check msg field → ✅/❌ step chips
+      parseValidationMsg(line, stepList);
+    };
+
+    es.onerror = function () {
+      es.close();
+      btn.disabled = false;
+      btn.textContent = label;
+      logEl.textContent += '\n❌ Connection closed\n';
+      finalize(stage, statusEl, stepList, logEl);
+    };
+  }
+
+  // ── Live solve parser ─────────────────────────────────────────────────────
+  // Tracks TASK [name] → ok/changed/failed lines and updates step chips live.
+  // Strips ANSI escape codes before matching (Ansible uses color codes).
+
+  function stripAnsi(s) {
+    return s.replace(/\u001b\[[0-9;]*[a-zA-Z]/g, '').replace(/\r/g, '');
+  }
+
+  function parseSolveLine(line, stepList, state, setState) {
+    var clean = stripAnsi(line);
+    var taskMatch = clean.match(/TASK \[([^\]]+)\]/);
+    if (taskMatch) {
+      var name = taskMatch[1].trim();
+      // Skip internal housekeeping tasks not meaningful to students
+      if (/^Gathering Facts$|^Build task results|^build task|^set_fact|^ansible\.builtin\.set_fact|^Validate all tasks$/i.test(name)) {
+        setState({ currentTask: null, pendingLi: null }); return;
+      }
+      var li = document.createElement('li');
+      li.className = 'sp-step sp-step-pending';
+      li.textContent = name;
+      stepList.appendChild(li);
+      setState({ currentTask: name, pendingLi: li });
+      return;
+    }
+    if (!state.pendingLi) return;
+
+    if (/^ok:\s*\[/.test(clean)) {
+      state.pendingLi.className = 'sp-step sp-step-ok';
+      state.pendingLi.textContent = state.currentTask;
+      setState({ currentTask: null, pendingLi: null });
+    } else if (/^changed:\s*\[/.test(clean)) {
+      state.pendingLi.className = 'sp-step sp-step-changed';
+      state.pendingLi.textContent = state.currentTask;
+      setState({ currentTask: null, pendingLi: null });
+    } else if (/^fatal:|^failed:\s*\[/i.test(clean)) {
+      state.pendingLi.className = 'sp-step sp-step-fail';
+      state.pendingLi.textContent = state.currentTask;
+      setState({ currentTask: null, pendingLi: null });
+    } else if (/^skipping:/i.test(clean)) {
+      state.pendingLi.remove();
+      setState({ currentTask: null, pendingLi: null });
+    }
+  }
+
+  // ── Live validate parser ──────────────────────────────────────────────────
+  // Adds ✅/❌ chips as validation_check lines stream in.
+
+  function parseValidateLine(line, stepList) {
+    var t = stripAnsi(line).trim();
+    if (/^✅/.test(t)) {
+      var li = document.createElement('li');
+      li.className = 'sp-step sp-step-ok';
+      li.textContent = t;
+      stepList.appendChild(li);
+    } else if (/^❌/.test(t)) {
+      var li2 = document.createElement('li');
+      li2.className = 'sp-step sp-step-fail';
+      li2.textContent = t;
+      stepList.appendChild(li2);
+    }
+  }
+
+  // ── validation_check msg parser ───────────────────────────────────────────
+  // validation_check writes pass/error msg to output.txt AND returns it in
+  // result['msg'] which appears in Ansible stdout as:
+  //   "msg": "✅ Task 1: ...\n✅ Task 2: ...\n : Message written to log"
+  // Extract each ✅/❌ line and show as a step chip.
+
+  function parseValidationMsg(line, stepList) {
+    var clean = stripAnsi(line).trim();
+    // Look for the "msg": "..." pattern from validation_check
+    // "msg": "..." — no closing } on this line, match to end of string
+    var msgMatch = clean.match(/"msg":\s*"(.+)"$/);
+    if (!msgMatch) return;
+    var msg = msgMatch[1].replace(/\\n/g, '\n').replace(/\\"/g, '"');
+    msg.split('\n').forEach(function (part) {
+      var t = part.trim();
+      if (/^✅/.test(t)) {
+        var li = document.createElement('li');
+        li.className = 'sp-step sp-step-ok';
+        li.textContent = t;
+        stepList.appendChild(li);
+      } else if (/^❌/.test(t)) {
+        var li2 = document.createElement('li');
+        li2.className = 'sp-step sp-step-fail';
+        li2.textContent = t;
+        stepList.appendChild(li2);
+      }
+    });
+  }
+
+  // ── Finalize status banner ────────────────────────────────────────────────
+
+  function finalize(stage, statusEl, stepList, logEl) {
+    var hasFail = stepList.querySelector('.sp-step-fail');
+    var hasPending = stepList.querySelector('.sp-step-pending');
+    if (hasPending) { hasPending.className = 'sp-step sp-step-fail'; }
+    hasFail = stepList.querySelector('.sp-step-fail');
+
+    var passed = !hasFail;
+    var text = stage === 'solve'
+      ? (passed ? 'Solve completed' : 'Solve failed')
+      : (passed ? 'All checks passed' : 'Validation failed');
+    var cls  = passed ? 'sp-status-pass' : 'sp-status-fail';
+
+    statusEl.innerHTML = '<span class="' + cls + '">' + escHtml(text) + '</span>';
+  }
+
+  function escHtml(str) {
+    return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  }
+
+  // ── Boot ──────────────────────────────────────────────────────────────────
+
+  function init() { initSendTo(); initSolve(); initValidate(); }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})();

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -75,6 +75,7 @@
         sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
           "grype {{ image_ref }} --add-cpes-if-none -o json > ~/scan-results.json 2>&1 || true"
       changed_when: true
+      ignore_errors: true
       timeout: 120
 
     - name: Generate SBOM with Syft on RHEL VM

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -102,9 +102,11 @@
       changed_when: true
       no_log: true
 
-    - name: Attach SBOM as attestation on RHEL VM
+    - name: Attest SBOM with Cosign on RHEL VM
       ansible.builtin.shell: |
         sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
-          "cd ~ && COSIGN_PASSWORD='' cosign attach attestation --attestation sbom.json --allow-insecure-registry {{ image_ref }} 2>&1 || true"
+          "cd ~ && COSIGN_PASSWORD='' cosign attest --key cosign.key \
+           --predicate sbom.json --type spdxjson \
+           --allow-insecure-registry {{ image_ref }} 2>&1 || true"
       changed_when: true
       no_log: true

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -1,8 +1,9 @@
 ---
 # SOLVE — Module 1: Zero CVE Containers on RHEL VM
-# Runner: zt-runner sidecar pod on OCP with cluster-admin SA kubeconfig
-# SSH to RHEL VM via virtctl using the SA kubeconfig
-# Extravars: k8s_kubeconfig, student_user, guid, domain
+# SSH directly to VM IP via sshpass (no virtctl needed).
+# VM IP is read from VirtualMachineInstance status via kubernetes.core.
+# Extravars: k8s_kubeconfig, student_user, guid, quay_hostname, quay_user,
+#            password, rhel_vm_user, rhel_vm_password
 
 - name: Module 1 Solve
   hosts: localhost
@@ -11,146 +12,123 @@
   vars:
     rhel_ns: "{{ student_user }}-rhel"
     vm_name: rhel
-    vm_user: rhel
-    quay_host: "{{ quay_hostname }}"
-    quay_user: "{{ quay_user }}"
-    repo_url: https://github.com/tosin2013/sample-quarkus-hummingbird.git
+    vm_user: "{{ rhel_vm_user | default('rhel') }}"
+    vm_password: "{{ rhel_vm_password | default(password) }}"
     image_ref: "{{ quay_hostname }}/{{ quay_user }}/secure-quarkus-jvm:latest"
+    repo_url: https://github.com/tosin2013/sample-quarkus-hummingbird.git
 
   tasks:
 
-    # ── Bootstrap: download virtctl from cluster downloads route ─────────
+    # ── Bootstrap: get VM IP from VMI ─────────────────────────────────────
 
-    - name: Download virtctl from cluster downloads route
-      ansible.builtin.get_url:
-        url: "https://downloads.{{ openshift_cluster_ingress_domain }}/amd64/linux/virtctl"
-        dest: /tmp/virtctl
-        mode: "0755"
+    - name: Get VirtualMachineInstance status
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
         validate_certs: false
-      register: r_virtctl_download
-      ignore_errors: true
+        api_version: kubevirt.io/v1
+        kind: VirtualMachineInstance
+        name: "{{ vm_name }}"
+        namespace: "{{ rhel_ns }}"
+      register: r_vmi
 
-    - name: Fallback — download virtctl from GitHub releases
-      ansible.builtin.shell: |
-        curl -skL "https://github.com/kubevirt/kubevirt/releases/latest/download/virtctl-linux-amd64" \
-          -o /tmp/virtctl && chmod +x /tmp/virtctl
-      when: r_virtctl_download is failed
-      changed_when: true
+    - name: Set VM IP
+      ansible.builtin.set_fact:
+        vm_ip: "{{ r_vmi.resources[0].status.interfaces[0].ipAddress }}"
 
     # ── Task 1: Build multi-stage Quarkus image ────────────────────────────
 
     - name: Clone sample Quarkus repo on RHEL VM
-      ansible.builtin.command:
-        cmd: >
-          /tmp/virtctl ssh {{ vm_name }}
-          -n {{ rhel_ns }}
-          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
-          --local-ssh-opts="-o StrictHostKeyChecking=no"
-          -- "rm -rf ~/sample-quarkus-hummingbird &&
-              git clone {{ repo_url }} ~/sample-quarkus-hummingbird"
+      ansible.builtin.shell: >
+        sshpass -p "{{ vm_password }}"
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ vm_user }}@{{ vm_ip }}
+        "rm -rf ~/sample-quarkus-hummingbird &&
+         git clone {{ repo_url }} ~/sample-quarkus-hummingbird"
       changed_when: true
+      no_log: true
 
     - name: Build Quarkus image with Buildah on RHEL VM
-      ansible.builtin.command:
-        cmd: >
-          /tmp/virtctl ssh {{ vm_name }}
-          -n {{ rhel_ns }}
-          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
-          --local-ssh-opts="-o StrictHostKeyChecking=no"
-          -- "cd ~/sample-quarkus-hummingbird &&
-              buildah bud --format=oci
-              -t {{ image_ref }} ."
+      ansible.builtin.shell: >
+        sshpass -p "{{ vm_password }}"
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ vm_user }}@{{ vm_ip }}
+        "cd ~/sample-quarkus-hummingbird &&
+         buildah bud --format=oci -t {{ image_ref }} ."
       changed_when: true
+      no_log: true
       timeout: 300
 
     - name: Log in to Quay registry on RHEL VM
-      ansible.builtin.command:
-        cmd: >
-          /tmp/virtctl ssh {{ vm_name }}
-          -n {{ rhel_ns }}
-          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
-          --local-ssh-opts="-o StrictHostKeyChecking=no"
-          -- "podman login {{ quay_host }}
-              --username={{ quay_user }}
-              --password={{ password }}"
+      ansible.builtin.shell: >
+        sshpass -p "{{ vm_password }}"
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ vm_user }}@{{ vm_ip }}
+        "podman login {{ quay_hostname }}
+         --username={{ quay_user }} --password={{ password }}"
       changed_when: true
       no_log: true
 
     - name: Push image to Quay on RHEL VM
-      ansible.builtin.command:
-        cmd: >
-          /tmp/virtctl ssh {{ vm_name }}
-          -n {{ rhel_ns }}
-          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
-          --local-ssh-opts="-o StrictHostKeyChecking=no"
-          -- "buildah push --tls-verify=false
-              {{ image_ref }}
-              docker://{{ image_ref }}"
+      ansible.builtin.shell: >
+        sshpass -p "{{ vm_password }}"
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ vm_user }}@{{ vm_ip }}
+        "buildah push --tls-verify=false {{ image_ref }} docker://{{ image_ref }}"
       changed_when: true
+      no_log: true
       timeout: 120
 
     # ── Task 2: Vulnerability scan + SBOM ─────────────────────────────────
 
     - name: Run Grype vulnerability scan on RHEL VM
-      ansible.builtin.command:
-        cmd: >
-          /tmp/virtctl ssh {{ vm_name }}
-          -n {{ rhel_ns }}
-          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
-          --local-ssh-opts="-o StrictHostKeyChecking=no"
-          -- "grype {{ image_ref }} --add-cpes-if-none
-              -o json > ~/scan-results.json 2>&1 || true"
+      ansible.builtin.shell: >
+        sshpass -p "{{ vm_password }}"
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ vm_user }}@{{ vm_ip }}
+        "grype {{ image_ref }} --add-cpes-if-none
+         -o json > ~/scan-results.json 2>&1 || true"
       changed_when: true
+      no_log: true
       timeout: 120
 
     - name: Generate SBOM with Syft on RHEL VM
-      ansible.builtin.command:
-        cmd: >
-          /tmp/virtctl ssh {{ vm_name }}
-          -n {{ rhel_ns }}
-          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
-          --local-ssh-opts="-o StrictHostKeyChecking=no"
-          -- "syft {{ image_ref }}
-              -o spdx-json > ~/sbom.json 2>&1"
+      ansible.builtin.shell: >
+        sshpass -p "{{ vm_password }}"
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ vm_user }}@{{ vm_ip }}
+        "syft {{ image_ref }} -o spdx-json > ~/sbom.json 2>&1"
       changed_when: true
+      no_log: true
       timeout: 120
 
     # ── Task 3: Sign image with Cosign ────────────────────────────────────
 
     - name: Generate Cosign key pair on RHEL VM
-      ansible.builtin.command:
-        cmd: >
-          /tmp/virtctl ssh {{ vm_name }}
-          -n {{ rhel_ns }}
-          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
-          --local-ssh-opts="-o StrictHostKeyChecking=no"
-          -- "cd ~ &&
-              COSIGN_PASSWORD='' cosign generate-key-pair 2>&1 || true"
+      ansible.builtin.shell: >
+        sshpass -p "{{ vm_password }}"
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ vm_user }}@{{ vm_ip }}
+        "cd ~ && COSIGN_PASSWORD='' cosign generate-key-pair 2>&1 || true"
       changed_when: true
+      no_log: true
 
     - name: Sign image with Cosign on RHEL VM
-      ansible.builtin.command:
-        cmd: >
-          /tmp/virtctl ssh {{ vm_name }}
-          -n {{ rhel_ns }}
-          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
-          --local-ssh-opts="-o StrictHostKeyChecking=no"
-          -- "cd ~ &&
-              COSIGN_PASSWORD='' cosign sign --key cosign.key
-              --allow-insecure-registry
-              {{ image_ref }} 2>&1"
+      ansible.builtin.shell: >
+        sshpass -p "{{ vm_password }}"
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ vm_user }}@{{ vm_ip }}
+        "cd ~ && COSIGN_PASSWORD='' cosign sign --key cosign.key
+         --allow-insecure-registry {{ image_ref }} 2>&1"
       changed_when: true
+      no_log: true
 
-    - name: Attach SBOM as attestation with Cosign on RHEL VM
-      ansible.builtin.command:
-        cmd: >
-          /tmp/virtctl ssh {{ vm_name }}
-          -n {{ rhel_ns }}
-          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
-          --local-ssh-opts="-o StrictHostKeyChecking=no"
-          -- "cd ~ &&
-              COSIGN_PASSWORD='' cosign attach attestation
-              --attestation sbom.json
-              --allow-insecure-registry
-              {{ image_ref }} 2>&1 || true"
+    - name: Attach SBOM as attestation on RHEL VM
+      ansible.builtin.shell: >
+        sshpass -p "{{ vm_password }}"
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ vm_user }}@{{ vm_ip }}
+        "cd ~ && COSIGN_PASSWORD='' cosign attach attestation
+         --attestation sbom.json
+         --allow-insecure-registry {{ image_ref }} 2>&1 || true"
       changed_when: true
+      no_log: true

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -1,0 +1,138 @@
+---
+# SOLVE — Module 1: Zero CVE Containers on RHEL VM
+# Runner: zt-runner sidecar pod on OCP with cluster-admin SA kubeconfig
+# SSH to RHEL VM via virtctl using the SA kubeconfig
+# Extravars: k8s_kubeconfig, student_user, guid, domain
+
+- name: Module 1 Solve
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    rhel_ns: "{{ student_user }}-rhel"
+    vm_name: rhel
+    vm_user: rhel
+    quay_host: "quay.{{ domain }}"
+    quay_user: "{{ student_user }}"
+    repo_url: https://github.com/tosin2013/sample-quarkus-hummingbird.git
+    image_ref: "quay.{{ domain }}/{{ student_user }}/secure-quarkus-jvm:latest"
+
+  tasks:
+
+    # ── Task 1: Build multi-stage Quarkus image ────────────────────────────
+
+    - name: Clone sample Quarkus repo on RHEL VM
+      ansible.builtin.command:
+        cmd: >
+          virtctl ssh {{ vm_name }}
+          -n {{ rhel_ns }}
+          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
+          --local-ssh-opts="-o StrictHostKeyChecking=no"
+          -- "rm -rf ~/sample-quarkus-hummingbird &&
+              git clone {{ repo_url }} ~/sample-quarkus-hummingbird"
+      changed_when: true
+
+    - name: Build Quarkus image with Buildah on RHEL VM
+      ansible.builtin.command:
+        cmd: >
+          virtctl ssh {{ vm_name }}
+          -n {{ rhel_ns }}
+          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
+          --local-ssh-opts="-o StrictHostKeyChecking=no"
+          -- "cd ~/sample-quarkus-hummingbird &&
+              buildah bud --format=oci
+              -t {{ image_ref }} ."
+      changed_when: true
+      timeout: 300
+
+    - name: Log in to Quay registry on RHEL VM
+      ansible.builtin.command:
+        cmd: >
+          virtctl ssh {{ vm_name }}
+          -n {{ rhel_ns }}
+          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
+          --local-ssh-opts="-o StrictHostKeyChecking=no"
+          -- "podman login {{ quay_host }}
+              --username={{ quay_user }}
+              --password={{ password }}"
+      changed_when: true
+      no_log: true
+
+    - name: Push image to Quay on RHEL VM
+      ansible.builtin.command:
+        cmd: >
+          virtctl ssh {{ vm_name }}
+          -n {{ rhel_ns }}
+          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
+          --local-ssh-opts="-o StrictHostKeyChecking=no"
+          -- "buildah push --tls-verify=false
+              {{ image_ref }}
+              docker://{{ image_ref }}"
+      changed_when: true
+      timeout: 120
+
+    # ── Task 2: Vulnerability scan + SBOM ─────────────────────────────────
+
+    - name: Run Grype vulnerability scan on RHEL VM
+      ansible.builtin.command:
+        cmd: >
+          virtctl ssh {{ vm_name }}
+          -n {{ rhel_ns }}
+          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
+          --local-ssh-opts="-o StrictHostKeyChecking=no"
+          -- "grype {{ image_ref }} --add-cpes-if-none
+              -o json > ~/scan-results.json 2>&1 || true"
+      changed_when: true
+      timeout: 120
+
+    - name: Generate SBOM with Syft on RHEL VM
+      ansible.builtin.command:
+        cmd: >
+          virtctl ssh {{ vm_name }}
+          -n {{ rhel_ns }}
+          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
+          --local-ssh-opts="-o StrictHostKeyChecking=no"
+          -- "syft {{ image_ref }}
+              -o spdx-json > ~/sbom.json 2>&1"
+      changed_when: true
+      timeout: 120
+
+    # ── Task 3: Sign image with Cosign ────────────────────────────────────
+
+    - name: Generate Cosign key pair on RHEL VM
+      ansible.builtin.command:
+        cmd: >
+          virtctl ssh {{ vm_name }}
+          -n {{ rhel_ns }}
+          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
+          --local-ssh-opts="-o StrictHostKeyChecking=no"
+          -- "cd ~ &&
+              COSIGN_PASSWORD='' cosign generate-key-pair 2>&1 || true"
+      changed_when: true
+
+    - name: Sign image with Cosign on RHEL VM
+      ansible.builtin.command:
+        cmd: >
+          virtctl ssh {{ vm_name }}
+          -n {{ rhel_ns }}
+          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
+          --local-ssh-opts="-o StrictHostKeyChecking=no"
+          -- "cd ~ &&
+              COSIGN_PASSWORD='' cosign sign --key cosign.key
+              --allow-insecure-registry
+              {{ image_ref }} 2>&1"
+      changed_when: true
+
+    - name: Attach SBOM as attestation with Cosign on RHEL VM
+      ansible.builtin.command:
+        cmd: >
+          virtctl ssh {{ vm_name }}
+          -n {{ rhel_ns }}
+          --kubeconfig={{ k8s_kubeconfig | default(omit) }}
+          --local-ssh-opts="-o StrictHostKeyChecking=no"
+          -- "cd ~ &&
+              COSIGN_PASSWORD='' cosign attach attestation
+              --attestation sbom.json
+              --allow-insecure-registry
+              {{ image_ref }} 2>&1 || true"
+      changed_when: true

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -75,7 +75,6 @@
         sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
           "grype {{ image_ref }} --add-cpes-if-none -o json > ~/scan-results.json 2>&1 || true"
       changed_when: true
-      no_log: true
       timeout: 120
 
     - name: Generate SBOM with Syft on RHEL VM
@@ -83,7 +82,7 @@
         sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
           "syft {{ image_ref }} -o spdx-json > ~/sbom.json 2>&1"
       changed_when: true
-      no_log: true
+      ignore_errors: true
       timeout: 120
 
     # ── Task 3: Sign image with Cosign ────────────────────────────────────

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -12,10 +12,10 @@
     rhel_ns: "{{ student_user }}-rhel"
     vm_name: rhel
     vm_user: rhel
-    quay_host: "quay.{{ domain }}"
-    quay_user: "{{ student_user }}"
+    quay_host: "{{ quay_hostname }}"
+    quay_user: "{{ quay_user }}"
     repo_url: https://github.com/tosin2013/sample-quarkus-hummingbird.git
-    image_ref: "quay.{{ domain }}/{{ student_user }}/secure-quarkus-jvm:latest"
+    image_ref: "{{ quay_hostname }}/{{ quay_user }}/secure-quarkus-jvm:latest"
 
   tasks:
 

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -19,6 +19,23 @@
 
   tasks:
 
+    # ── Bootstrap: install virtctl if not present ──────────────────────────
+
+    - name: Check if virtctl is installed
+      ansible.builtin.command: which virtctl
+      register: r_virtctl
+      ignore_errors: true
+      changed_when: false
+
+    - name: Download virtctl from cluster
+      ansible.builtin.shell: |
+        ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+        curl -skL "https://github.com/kubevirt/kubevirt/releases/latest/download/virtctl-linux-${ARCH}" \
+          -o /tmp/virtctl && chmod +x /tmp/virtctl
+        ln -sf /tmp/virtctl /usr/local/bin/virtctl
+      when: r_virtctl.rc != 0
+      changed_when: true
+
     # ── Task 1: Build multi-stage Quarkus image ────────────────────────────
 
     - name: Clone sample Quarkus repo on RHEL VM

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -16,6 +16,7 @@
     vm_password: "{{ rhel_vm_password | default(password) }}"
     image_ref: "{{ quay_hostname }}/{{ quay_user }}/secure-quarkus-jvm:latest"
     repo_url: https://github.com/tosin2013/sample-quarkus-hummingbird.git
+    ssh_opts: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
   tasks:
 
@@ -38,42 +39,31 @@
     # ── Task 1: Build multi-stage Quarkus image ────────────────────────────
 
     - name: Clone sample Quarkus repo on RHEL VM
-      ansible.builtin.shell: >
-        sshpass -p "{{ vm_password }}"
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-        {{ vm_user }}@{{ vm_ip }}
-        "rm -rf ~/sample-quarkus-hummingbird &&
-         git clone {{ repo_url }} ~/sample-quarkus-hummingbird"
+      ansible.builtin.shell: |
+        sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
+          "rm -rf ~/sample-quarkus-hummingbird && git clone {{ repo_url }} ~/sample-quarkus-hummingbird"
       changed_when: true
       no_log: true
 
     - name: Build Quarkus image with Buildah on RHEL VM
-      ansible.builtin.shell: >
-        sshpass -p "{{ vm_password }}"
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-        {{ vm_user }}@{{ vm_ip }}
-        "cd ~/sample-quarkus-hummingbird &&
-         buildah bud --format=oci -t {{ image_ref }} ."
+      ansible.builtin.shell: |
+        sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
+          "cd ~/sample-quarkus-hummingbird && buildah bud --format=oci -t {{ image_ref }} ."
       changed_when: true
       no_log: true
       timeout: 300
 
     - name: Log in to Quay registry on RHEL VM
-      ansible.builtin.shell: >
-        sshpass -p "{{ vm_password }}"
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-        {{ vm_user }}@{{ vm_ip }}
-        "podman login {{ quay_hostname }}
-         --username={{ quay_user }} --password={{ password }}
-         --tls-verify=false"
+      ansible.builtin.shell: |
+        sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
+          "podman login {{ quay_hostname }} --username={{ quay_user }} --password={{ password }} --tls-verify=false"
       changed_when: true
+      no_log: true
 
     - name: Push image to Quay on RHEL VM
-      ansible.builtin.shell: >
-        sshpass -p "{{ vm_password }}"
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-        {{ vm_user }}@{{ vm_ip }}
-        "buildah push --tls-verify=false {{ image_ref }} docker://{{ image_ref }}"
+      ansible.builtin.shell: |
+        sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
+          "buildah push --tls-verify=false {{ image_ref }} docker://{{ image_ref }}"
       changed_when: true
       no_log: true
       timeout: 120
@@ -81,22 +71,17 @@
     # ── Task 2: Vulnerability scan + SBOM ─────────────────────────────────
 
     - name: Run Grype vulnerability scan on RHEL VM
-      ansible.builtin.shell: >
-        sshpass -p "{{ vm_password }}"
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-        {{ vm_user }}@{{ vm_ip }}
-        "grype {{ image_ref }} --add-cpes-if-none
-         -o json > ~/scan-results.json 2>&1 || true"
+      ansible.builtin.shell: |
+        sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
+          "grype {{ image_ref }} --add-cpes-if-none -o json > ~/scan-results.json 2>&1 || true"
       changed_when: true
       no_log: true
       timeout: 120
 
     - name: Generate SBOM with Syft on RHEL VM
-      ansible.builtin.shell: >
-        sshpass -p "{{ vm_password }}"
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-        {{ vm_user }}@{{ vm_ip }}
-        "syft {{ image_ref }} -o spdx-json > ~/sbom.json 2>&1"
+      ansible.builtin.shell: |
+        sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
+          "syft {{ image_ref }} -o spdx-json > ~/sbom.json 2>&1"
       changed_when: true
       no_log: true
       timeout: 120
@@ -104,31 +89,22 @@
     # ── Task 3: Sign image with Cosign ────────────────────────────────────
 
     - name: Generate Cosign key pair on RHEL VM
-      ansible.builtin.shell: >
-        sshpass -p "{{ vm_password }}"
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-        {{ vm_user }}@{{ vm_ip }}
-        "cd ~ && COSIGN_PASSWORD='' cosign generate-key-pair 2>&1 || true"
+      ansible.builtin.shell: |
+        sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
+          "cd ~ && COSIGN_PASSWORD='' cosign generate-key-pair 2>&1 || true"
       changed_when: true
       no_log: true
 
     - name: Sign image with Cosign on RHEL VM
-      ansible.builtin.shell: >
-        sshpass -p "{{ vm_password }}"
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-        {{ vm_user }}@{{ vm_ip }}
-        "cd ~ && COSIGN_PASSWORD='' cosign sign --key cosign.key
-         --allow-insecure-registry {{ image_ref }} 2>&1"
+      ansible.builtin.shell: |
+        sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
+          "cd ~ && COSIGN_PASSWORD='' cosign sign --key cosign.key --allow-insecure-registry {{ image_ref }} 2>&1"
       changed_when: true
       no_log: true
 
     - name: Attach SBOM as attestation on RHEL VM
-      ansible.builtin.shell: >
-        sshpass -p "{{ vm_password }}"
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-        {{ vm_user }}@{{ vm_ip }}
-        "cd ~ && COSIGN_PASSWORD='' cosign attach attestation
-         --attestation sbom.json
-         --allow-insecure-registry {{ image_ref }} 2>&1 || true"
+      ansible.builtin.shell: |
+        sshpass -p "{{ vm_password }}" ssh {{ ssh_opts }} {{ vm_user }}@{{ vm_ip }} \
+          "cd ~ && COSIGN_PASSWORD='' cosign attach attestation --attestation sbom.json --allow-insecure-registry {{ image_ref }} 2>&1 || true"
       changed_when: true
       no_log: true

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -19,21 +19,22 @@
 
   tasks:
 
-    # ── Bootstrap: install virtctl if not present ──────────────────────────
+    # ── Bootstrap: download virtctl from cluster downloads route ─────────
 
-    - name: Check if virtctl is installed
-      ansible.builtin.command: which virtctl
-      register: r_virtctl
+    - name: Download virtctl from cluster downloads route
+      ansible.builtin.get_url:
+        url: "https://downloads.{{ openshift_cluster_ingress_domain }}/amd64/linux/virtctl"
+        dest: /tmp/virtctl
+        mode: "0755"
+        validate_certs: false
+      register: r_virtctl_download
       ignore_errors: true
-      changed_when: false
 
-    - name: Download virtctl from cluster
+    - name: Fallback — download virtctl from GitHub releases
       ansible.builtin.shell: |
-        ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-        curl -skL "https://github.com/kubevirt/kubevirt/releases/latest/download/virtctl-linux-${ARCH}" \
+        curl -skL "https://github.com/kubevirt/kubevirt/releases/latest/download/virtctl-linux-amd64" \
           -o /tmp/virtctl && chmod +x /tmp/virtctl
-        ln -sf /tmp/virtctl /usr/local/bin/virtctl
-      when: r_virtctl.rc != 0
+      when: r_virtctl_download is failed
       changed_when: true
 
     # ── Task 1: Build multi-stage Quarkus image ────────────────────────────
@@ -41,7 +42,7 @@
     - name: Clone sample Quarkus repo on RHEL VM
       ansible.builtin.command:
         cmd: >
-          virtctl ssh {{ vm_name }}
+          /tmp/virtctl ssh {{ vm_name }}
           -n {{ rhel_ns }}
           --kubeconfig={{ k8s_kubeconfig | default(omit) }}
           --local-ssh-opts="-o StrictHostKeyChecking=no"
@@ -52,7 +53,7 @@
     - name: Build Quarkus image with Buildah on RHEL VM
       ansible.builtin.command:
         cmd: >
-          virtctl ssh {{ vm_name }}
+          /tmp/virtctl ssh {{ vm_name }}
           -n {{ rhel_ns }}
           --kubeconfig={{ k8s_kubeconfig | default(omit) }}
           --local-ssh-opts="-o StrictHostKeyChecking=no"
@@ -65,7 +66,7 @@
     - name: Log in to Quay registry on RHEL VM
       ansible.builtin.command:
         cmd: >
-          virtctl ssh {{ vm_name }}
+          /tmp/virtctl ssh {{ vm_name }}
           -n {{ rhel_ns }}
           --kubeconfig={{ k8s_kubeconfig | default(omit) }}
           --local-ssh-opts="-o StrictHostKeyChecking=no"
@@ -78,7 +79,7 @@
     - name: Push image to Quay on RHEL VM
       ansible.builtin.command:
         cmd: >
-          virtctl ssh {{ vm_name }}
+          /tmp/virtctl ssh {{ vm_name }}
           -n {{ rhel_ns }}
           --kubeconfig={{ k8s_kubeconfig | default(omit) }}
           --local-ssh-opts="-o StrictHostKeyChecking=no"
@@ -93,7 +94,7 @@
     - name: Run Grype vulnerability scan on RHEL VM
       ansible.builtin.command:
         cmd: >
-          virtctl ssh {{ vm_name }}
+          /tmp/virtctl ssh {{ vm_name }}
           -n {{ rhel_ns }}
           --kubeconfig={{ k8s_kubeconfig | default(omit) }}
           --local-ssh-opts="-o StrictHostKeyChecking=no"
@@ -105,7 +106,7 @@
     - name: Generate SBOM with Syft on RHEL VM
       ansible.builtin.command:
         cmd: >
-          virtctl ssh {{ vm_name }}
+          /tmp/virtctl ssh {{ vm_name }}
           -n {{ rhel_ns }}
           --kubeconfig={{ k8s_kubeconfig | default(omit) }}
           --local-ssh-opts="-o StrictHostKeyChecking=no"
@@ -119,7 +120,7 @@
     - name: Generate Cosign key pair on RHEL VM
       ansible.builtin.command:
         cmd: >
-          virtctl ssh {{ vm_name }}
+          /tmp/virtctl ssh {{ vm_name }}
           -n {{ rhel_ns }}
           --kubeconfig={{ k8s_kubeconfig | default(omit) }}
           --local-ssh-opts="-o StrictHostKeyChecking=no"
@@ -130,7 +131,7 @@
     - name: Sign image with Cosign on RHEL VM
       ansible.builtin.command:
         cmd: >
-          virtctl ssh {{ vm_name }}
+          /tmp/virtctl ssh {{ vm_name }}
           -n {{ rhel_ns }}
           --kubeconfig={{ k8s_kubeconfig | default(omit) }}
           --local-ssh-opts="-o StrictHostKeyChecking=no"
@@ -143,7 +144,7 @@
     - name: Attach SBOM as attestation with Cosign on RHEL VM
       ansible.builtin.command:
         cmd: >
-          virtctl ssh {{ vm_name }}
+          /tmp/virtctl ssh {{ vm_name }}
           -n {{ rhel_ns }}
           --kubeconfig={{ k8s_kubeconfig | default(omit) }}
           --local-ssh-opts="-o StrictHostKeyChecking=no"

--- a/runtime-automation/module-01/solve.yml
+++ b/runtime-automation/module-01/solve.yml
@@ -64,9 +64,9 @@
         ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
         {{ vm_user }}@{{ vm_ip }}
         "podman login {{ quay_hostname }}
-         --username={{ quay_user }} --password={{ password }}"
+         --username={{ quay_user }} --password={{ password }}
+         --tls-verify=false"
       changed_when: true
-      no_log: true
 
     - name: Push image to Quay on RHEL VM
       ansible.builtin.shell: >

--- a/runtime-automation/module-01/validate.yml
+++ b/runtime-automation/module-01/validate.yml
@@ -50,10 +50,6 @@
         status_code: [200, 401, 404]
       register: r_tags
 
-    - name: Debug tags response
-      ansible.builtin.debug:
-        msg: "status={{ r_tags.status }} tags={{ r_tags.json.tags | default([]) }}"
-
     # ── Build results ──────────────────────────────────────────────────────
 
     - name: Build results

--- a/runtime-automation/module-01/validate.yml
+++ b/runtime-automation/module-01/validate.yml
@@ -30,18 +30,9 @@
 
     # ── Task 2: Image pushed to Quay ──────────────────────────────────────
 
-    - name: Get Quay OAuth token
-      ansible.builtin.uri:
-        url: "https://{{ quay_host }}/api/v1/user/initialize"
-        method: POST
-        body_format: json
-        body:
-          username: "{{ quay_user }}"
-          password: "{{ password }}"
-          access_token: true
-        validate_certs: false
-        status_code: [200, 201, 400]
-      register: r_quay_token
+    - name: Set Quay basic auth header
+      ansible.builtin.set_fact:
+        _quay_auth: "Basic {{ (quay_user + ':' + password) | b64encode }}"
       no_log: true
 
     - name: Get image tags from Quay
@@ -49,7 +40,7 @@
         url: "https://{{ quay_host }}/api/v1/repository/{{ image_repo }}/tag/?specificTag=latest"
         method: GET
         headers:
-          Authorization: "Bearer {{ r_quay_token.json.access_token | default('') }}"
+          Authorization: "{{ _quay_auth }}"
         validate_certs: false
         status_code: [200, 404]
       register: r_quay_tags
@@ -61,7 +52,7 @@
         url: "https://{{ quay_host }}/api/v1/repository/{{ image_repo }}/tag/?specificTag=latest.sig"
         method: GET
         headers:
-          Authorization: "Bearer {{ r_quay_token.json.access_token | default('') }}"
+          Authorization: "{{ _quay_auth }}"
         validate_certs: false
         status_code: [200, 404]
       register: r_quay_sig
@@ -73,7 +64,7 @@
         url: "https://{{ quay_host }}/api/v1/repository/{{ image_repo }}/tag/?specificTag=latest.att"
         method: GET
         headers:
-          Authorization: "Bearer {{ r_quay_token.json.access_token | default('') }}"
+          Authorization: "{{ _quay_auth }}"
         validate_certs: false
         status_code: [200, 404]
       register: r_quay_att

--- a/runtime-automation/module-01/validate.yml
+++ b/runtime-automation/module-01/validate.yml
@@ -10,9 +10,9 @@
   vars:
     rhel_ns: "{{ student_user }}-rhel"
     vm_name: rhel
-    quay_host: "quay.{{ domain }}"
-    quay_user: "{{ student_user }}"
-    image_repo: "{{ student_user }}/secure-quarkus-jvm"
+    quay_host: "{{ quay_hostname }}"
+    quay_user: "{{ quay_user }}"
+    image_repo: "{{ quay_user }}/secure-quarkus-jvm"
 
   tasks:
 
@@ -111,6 +111,6 @@
 
           Fix — run on the RHEL VM terminal:
             cd ~/sample-quarkus-hummingbird
-            buildah bud --format=oci -t quay.{{ domain }}/{{ quay_user }}/secure-quarkus-jvm:latest .
-            buildah push quay.{{ domain }}/{{ quay_user }}/secure-quarkus-jvm:latest
-            COSIGN_PASSWORD='' cosign sign --key ~/cosign.key quay.{{ domain }}/{{ quay_user }}/secure-quarkus-jvm:latest
+            buildah bud --format=oci -t {{ quay_hostname }}/{{ quay_user }}/secure-quarkus-jvm:latest .
+            buildah push {{ quay_hostname }}/{{ quay_user }}/secure-quarkus-jvm:latest
+            COSIGN_PASSWORD='' cosign sign --key ~/cosign.key {{ quay_hostname }}/{{ quay_user }}/secure-quarkus-jvm:latest

--- a/runtime-automation/module-01/validate.yml
+++ b/runtime-automation/module-01/validate.yml
@@ -1,0 +1,116 @@
+---
+# VALIDATE — Module 1: Zero CVE Containers on RHEL VM
+# Checks via Quay API (accessible from OCP) + VM status via kubernetes.core
+# Extravars: k8s_kubeconfig, student_user, guid, domain, password
+
+- name: Module 1 Validation
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    rhel_ns: "{{ student_user }}-rhel"
+    vm_name: rhel
+    quay_host: "quay.{{ domain }}"
+    quay_user: "{{ student_user }}"
+    image_repo: "{{ student_user }}/secure-quarkus-jvm"
+
+  tasks:
+
+    # ── Task 1: RHEL VM is running ─────────────────────────────────────────
+
+    - name: Check RHEL VM is running
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        api_version: kubevirt.io/v1
+        kind: VirtualMachineInstance
+        name: "{{ vm_name }}"
+        namespace: "{{ rhel_ns }}"
+      register: r_vmi
+
+    # ── Task 2: Image pushed to Quay ──────────────────────────────────────
+
+    - name: Get Quay OAuth token
+      ansible.builtin.uri:
+        url: "https://{{ quay_host }}/api/v1/user/initialize"
+        method: POST
+        body_format: json
+        body:
+          username: "{{ quay_user }}"
+          password: "{{ password }}"
+          access_token: true
+        validate_certs: false
+        status_code: [200, 201, 400]
+      register: r_quay_token
+      no_log: true
+
+    - name: Get image tags from Quay
+      ansible.builtin.uri:
+        url: "https://{{ quay_host }}/api/v1/repository/{{ image_repo }}/tag/?specificTag=latest"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ r_quay_token.json.access_token | default('') }}"
+        validate_certs: false
+        status_code: [200, 404]
+      register: r_quay_tags
+
+    # ── Task 3: Cosign signature exists in Quay ───────────────────────────
+
+    - name: Get .sig tag from Quay (cosign signature)
+      ansible.builtin.uri:
+        url: "https://{{ quay_host }}/api/v1/repository/{{ image_repo }}/tag/?specificTag=latest.sig"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ r_quay_token.json.access_token | default('') }}"
+        validate_certs: false
+        status_code: [200, 404]
+      register: r_quay_sig
+
+    # ── Task 4: SBOM attestation exists in Quay ───────────────────────────
+
+    - name: Get .att tag from Quay (SBOM attestation)
+      ansible.builtin.uri:
+        url: "https://{{ quay_host }}/api/v1/repository/{{ image_repo }}/tag/?specificTag=latest.att"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ r_quay_token.json.access_token | default('') }}"
+        validate_certs: false
+        status_code: [200, 404]
+      register: r_quay_att
+
+    # ── Build results ──────────────────────────────────────────────────────
+
+    - name: Build results
+      ansible.builtin.set_fact:
+        _vm_ok: >-
+          {{ r_vmi.resources | length > 0 and
+             r_vmi.resources[0].status.phase | default('') == 'Running' }}
+        _image_ok: >-
+          {{ r_quay_tags.status == 200 and
+             r_quay_tags.json.tags | default([]) | length > 0 }}
+        _sig_ok: >-
+          {{ r_quay_sig.status == 200 and
+             r_quay_sig.json.tags | default([]) | length > 0 }}
+        _att_ok: >-
+          {{ r_quay_att.status == 200 and
+             r_quay_att.json.tags | default([]) | length > 0 }}
+
+    - name: Validate all tasks
+      validation_check:
+        check: "{{ _vm_ok and _image_ok and _sig_ok }}"
+        pass_msg: |
+          ✅ Task 1: RHEL VM is running in {{ rhel_ns }}
+          ✅ Task 2: Image secure-quarkus-jvm:latest pushed to Quay
+          ✅ Task 3: Cosign signature (.sig tag) found in Quay
+          {{ '✅' if _att_ok else '⚠️ ' }} Task 4: SBOM attestation (.att tag) in Quay
+        error_msg: |
+          {{ '✅' if _vm_ok else '❌' }} Task 1: RHEL VM running in {{ rhel_ns }}
+          {{ '✅' if _image_ok else '❌' }} Task 2: Image secure-quarkus-jvm:latest in Quay
+          {{ '✅' if _sig_ok else '❌' }} Task 3: Cosign signature (.sig) in Quay
+          {{ '✅' if _att_ok else '❌' }} Task 4: SBOM attestation (.att) in Quay
+
+          Fix — run on the RHEL VM terminal:
+            cd ~/sample-quarkus-hummingbird
+            buildah bud --format=oci -t quay.{{ domain }}/{{ quay_user }}/secure-quarkus-jvm:latest .
+            buildah push quay.{{ domain }}/{{ quay_user }}/secure-quarkus-jvm:latest
+            COSIGN_PASSWORD='' cosign sign --key ~/cosign.key quay.{{ domain }}/{{ quay_user }}/secure-quarkus-jvm:latest

--- a/runtime-automation/module-01/validate.yml
+++ b/runtime-automation/module-01/validate.yml
@@ -1,7 +1,7 @@
 ---
 # VALIDATE — Module 1: Zero CVE Containers on RHEL VM
-# Checks via Quay API (accessible from OCP) + VM status via kubernetes.core
-# Extravars: k8s_kubeconfig, student_user, guid, domain, password
+# Uses Docker V2 registry API with Bearer token to check image/sig/att tags.
+# Extravars: k8s_kubeconfig, student_user, guid, quay_hostname, quay_user, password
 
 - name: Module 1 Validation
   hosts: localhost
@@ -9,10 +9,8 @@
   gather_facts: false
   vars:
     rhel_ns: "{{ student_user }}-rhel"
-    vm_name: rhel
-    quay_host: "{{ quay_hostname }}"
-    quay_user: "{{ quay_user }}"
     image_repo: "{{ quay_user }}/secure-quarkus-jvm"
+    quay_host: "{{ quay_hostname }}"
 
   tasks:
 
@@ -24,16 +22,13 @@
         validate_certs: false
         api_version: kubevirt.io/v1
         kind: VirtualMachineInstance
-        name: "{{ vm_name }}"
+        name: rhel
         namespace: "{{ rhel_ns }}"
       register: r_vmi
 
-    # ── Task 2: Image pushed to Quay ──────────────────────────────────────
+    # ── Tasks 2-4: Check image/sig/att via Docker V2 Registry API ─────────
 
-    # ── Tasks 2-4: Check tags via Docker registry API /v2/ ────────────────
-    # /v2/ supports Basic auth natively; /api/v1/ requires OAuth token.
-
-    - name: Get Docker registry token for Quay
+    - name: Get Docker V2 Bearer token for Quay
       ansible.builtin.uri:
         url: "https://{{ quay_host }}/v2/auth?service={{ quay_host }}&scope=repository:{{ image_repo }}:pull"
         method: GET
@@ -45,47 +40,15 @@
       register: r_token
       no_log: true
 
-    - name: Set registry auth header
-      ansible.builtin.set_fact:
-        _reg_auth: "Bearer {{ r_token.json.token | default('') }}"
-      no_log: true
-
-    - name: Check image manifest exists (latest tag)
+    - name: Get all tags from Quay registry
       ansible.builtin.uri:
-        url: "https://{{ quay_host }}/v2/{{ image_repo }}/manifests/latest"
-        method: HEAD
+        url: "https://{{ quay_host }}/v2/{{ image_repo }}/tags/list"
+        method: GET
         headers:
-          Authorization: "{{ _reg_auth }}"
-          Accept: "application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json"
+          Authorization: "Bearer {{ r_token.json.token | default('') }}"
         validate_certs: false
         status_code: [200, 401, 404]
-      register: r_quay_tags
-
-    # ── Task 3: Cosign signature exists ───────────────────────────────────
-
-    - name: Check .sig tag exists (cosign signature)
-      ansible.builtin.uri:
-        url: "https://{{ quay_host }}/v2/{{ image_repo }}/manifests/latest.sig"
-        method: HEAD
-        headers:
-          Authorization: "{{ _reg_auth }}"
-          Accept: "application/vnd.oci.image.manifest.v1+json"
-        validate_certs: false
-        status_code: [200, 401, 404]
-      register: r_quay_sig
-
-    # ── Task 4: SBOM attestation exists ───────────────────────────────────
-
-    - name: Check .att tag exists (SBOM attestation)
-      ansible.builtin.uri:
-        url: "https://{{ quay_host }}/v2/{{ image_repo }}/manifests/latest.att"
-        method: HEAD
-        headers:
-          Authorization: "{{ _reg_auth }}"
-          Accept: "application/vnd.oci.image.manifest.v1+json"
-        validate_certs: false
-        status_code: [200, 401, 404]
-      register: r_quay_att
+      register: r_tags
 
     # ── Build results ──────────────────────────────────────────────────────
 
@@ -94,9 +57,15 @@
         _vm_ok: >-
           {{ r_vmi.resources | length > 0 and
              r_vmi.resources[0].status.phase | default('') == 'Running' }}
-        _image_ok: "{{ r_quay_tags.status == 200 }}"
-        _sig_ok: "{{ r_quay_sig.status == 200 }}"
-        _att_ok: "{{ r_quay_att.status == 200 }}"
+        _image_ok: >-
+          {{ r_tags.status == 200 and
+             'latest' in (r_tags.json.tags | default([])) }}
+        _sig_ok: >-
+          {{ r_tags.status == 200 and
+             (r_tags.json.tags | default([])) | select('match', '.*\\.sig$') | list | length > 0 }}
+        _att_ok: >-
+          {{ r_tags.status == 200 and
+             (r_tags.json.tags | default([])) | select('match', '.*\\.att$') | list | length > 0 }}
 
     - name: Validate all tasks
       validation_check:
@@ -114,6 +83,6 @@
 
           Fix — run on the RHEL VM terminal:
             cd ~/sample-quarkus-hummingbird
-            buildah bud --format=oci -t {{ quay_hostname }}/{{ quay_user }}/secure-quarkus-jvm:latest .
-            buildah push {{ quay_hostname }}/{{ quay_user }}/secure-quarkus-jvm:latest
-            COSIGN_PASSWORD='' cosign sign --key ~/cosign.key {{ quay_hostname }}/{{ quay_user }}/secure-quarkus-jvm:latest
+            buildah bud --format=oci -t {{ quay_host }}/{{ quay_user }}/secure-quarkus-jvm:latest .
+            buildah push --tls-verify=false {{ quay_host }}/{{ quay_user }}/secure-quarkus-jvm:latest
+            COSIGN_PASSWORD='' cosign sign --key ~/cosign.key --allow-insecure-registry {{ quay_host }}/{{ quay_user }}/secure-quarkus-jvm:latest

--- a/runtime-automation/module-01/validate.yml
+++ b/runtime-automation/module-01/validate.yml
@@ -42,7 +42,7 @@
         headers:
           Authorization: "{{ _quay_auth }}"
         validate_certs: false
-        status_code: [200, 404]
+        status_code: [200, 401, 404]
       register: r_quay_tags
 
     # ── Task 3: Cosign signature exists in Quay ───────────────────────────
@@ -54,7 +54,7 @@
         headers:
           Authorization: "{{ _quay_auth }}"
         validate_certs: false
-        status_code: [200, 404]
+        status_code: [200, 401, 404]
       register: r_quay_sig
 
     # ── Task 4: SBOM attestation exists in Quay ───────────────────────────
@@ -66,7 +66,7 @@
         headers:
           Authorization: "{{ _quay_auth }}"
         validate_certs: false
-        status_code: [200, 404]
+        status_code: [200, 401, 404]
       register: r_quay_att
 
     # ── Build results ──────────────────────────────────────────────────────

--- a/runtime-automation/module-01/validate.yml
+++ b/runtime-automation/module-01/validate.yml
@@ -50,6 +50,10 @@
         status_code: [200, 401, 404]
       register: r_tags
 
+    - name: Debug tags response
+      ansible.builtin.debug:
+        msg: "status={{ r_tags.status }} tags={{ r_tags.json.tags | default([]) }}"
+
     # ── Build results ──────────────────────────────────────────────────────
 
     - name: Build results
@@ -62,10 +66,10 @@
              'latest' in (r_tags.json.tags | default([])) }}
         _sig_ok: >-
           {{ r_tags.status == 200 and
-             (r_tags.json.tags | default([])) | select('match', '.*\\.sig$') | list | length > 0 }}
+             (r_tags.json.tags | default([]) | join(' ')) is search('\.sig') }}
         _att_ok: >-
           {{ r_tags.status == 200 and
-             (r_tags.json.tags | default([])) | select('match', '.*\\.att$') | list | length > 0 }}
+             (r_tags.json.tags | default([]) | join(' ')) is search('\.att') }}
 
     - name: Validate all tasks
       validation_check:

--- a/runtime-automation/module-01/validate.yml
+++ b/runtime-automation/module-01/validate.yml
@@ -30,41 +30,59 @@
 
     # ── Task 2: Image pushed to Quay ──────────────────────────────────────
 
-    - name: Set Quay basic auth header
-      ansible.builtin.set_fact:
-        _quay_auth: "Basic {{ (quay_user + ':' + password) | b64encode }}"
+    # ── Tasks 2-4: Check tags via Docker registry API /v2/ ────────────────
+    # /v2/ supports Basic auth natively; /api/v1/ requires OAuth token.
+
+    - name: Get Docker registry token for Quay
+      ansible.builtin.uri:
+        url: "https://{{ quay_host }}/v2/auth?service={{ quay_host }}&scope=repository:{{ image_repo }}:pull"
+        method: GET
+        url_username: "{{ quay_user }}"
+        url_password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code: [200, 401]
+      register: r_token
       no_log: true
 
-    - name: Get image tags from Quay
+    - name: Set registry auth header
+      ansible.builtin.set_fact:
+        _reg_auth: "Bearer {{ r_token.json.token | default('') }}"
+      no_log: true
+
+    - name: Check image manifest exists (latest tag)
       ansible.builtin.uri:
-        url: "https://{{ quay_host }}/api/v1/repository/{{ image_repo }}/tag/?specificTag=latest"
-        method: GET
+        url: "https://{{ quay_host }}/v2/{{ image_repo }}/manifests/latest"
+        method: HEAD
         headers:
-          Authorization: "{{ _quay_auth }}"
+          Authorization: "{{ _reg_auth }}"
+          Accept: "application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json"
         validate_certs: false
         status_code: [200, 401, 404]
       register: r_quay_tags
 
-    # ── Task 3: Cosign signature exists in Quay ───────────────────────────
+    # ── Task 3: Cosign signature exists ───────────────────────────────────
 
-    - name: Get .sig tag from Quay (cosign signature)
+    - name: Check .sig tag exists (cosign signature)
       ansible.builtin.uri:
-        url: "https://{{ quay_host }}/api/v1/repository/{{ image_repo }}/tag/?specificTag=latest.sig"
-        method: GET
+        url: "https://{{ quay_host }}/v2/{{ image_repo }}/manifests/latest.sig"
+        method: HEAD
         headers:
-          Authorization: "{{ _quay_auth }}"
+          Authorization: "{{ _reg_auth }}"
+          Accept: "application/vnd.oci.image.manifest.v1+json"
         validate_certs: false
         status_code: [200, 401, 404]
       register: r_quay_sig
 
-    # ── Task 4: SBOM attestation exists in Quay ───────────────────────────
+    # ── Task 4: SBOM attestation exists ───────────────────────────────────
 
-    - name: Get .att tag from Quay (SBOM attestation)
+    - name: Check .att tag exists (SBOM attestation)
       ansible.builtin.uri:
-        url: "https://{{ quay_host }}/api/v1/repository/{{ image_repo }}/tag/?specificTag=latest.att"
-        method: GET
+        url: "https://{{ quay_host }}/v2/{{ image_repo }}/manifests/latest.att"
+        method: HEAD
         headers:
-          Authorization: "{{ _quay_auth }}"
+          Authorization: "{{ _reg_auth }}"
+          Accept: "application/vnd.oci.image.manifest.v1+json"
         validate_certs: false
         status_code: [200, 401, 404]
       register: r_quay_att
@@ -76,15 +94,9 @@
         _vm_ok: >-
           {{ r_vmi.resources | length > 0 and
              r_vmi.resources[0].status.phase | default('') == 'Running' }}
-        _image_ok: >-
-          {{ r_quay_tags.status == 200 and
-             r_quay_tags.json.tags | default([]) | length > 0 }}
-        _sig_ok: >-
-          {{ r_quay_sig.status == 200 and
-             r_quay_sig.json.tags | default([]) | length > 0 }}
-        _att_ok: >-
-          {{ r_quay_att.status == 200 and
-             r_quay_att.json.tags | default([]) | length > 0 }}
+        _image_ok: "{{ r_quay_tags.status == 200 }}"
+        _sig_ok: "{{ r_quay_sig.status == 200 }}"
+        _att_ok: "{{ r_quay_att.status == 200 }}"
 
     - name: Validate all tasks
       validation_check:

--- a/runtime-automation/module-02/solve.yml
+++ b/runtime-automation/module-02/solve.yml
@@ -10,8 +10,8 @@
   vars:
     build_ns: "{{ student_user }}-hummingbird-builds"
     prod_ns: "{{ student_user }}-hummingbird-production"
-    quay_host: "quay.{{ domain }}"
-    image_ref: "quay.{{ domain }}/{{ student_user }}/secure-quarkus:latest"
+    quay_host: "{{ quay_hostname }}"
+    image_ref: "{{ quay_hostname }}/{{ quay_user }}/secure-quarkus:latest"
     repo_url: https://github.com/tosin2013/sample-quarkus-hummingbird.git
 
   tasks:
@@ -32,7 +32,7 @@
           type: kubernetes.io/dockerconfigjson
           stringData:
             .dockerconfigjson: >-
-              {"auths":{"{{ quay_host }}":{"username":"{{ student_user }}","password":"{{ password }}","auth":"{{ (student_user + ':' + password) | b64encode }}"}}}
+              {"auths":{"{{ quay_host }}":{"username":"{{ quay_user }}","password":"{{ password }}","auth":"{{ (quay_user + ':' + password) | b64encode }}"}}}
       no_log: true
 
     # ── Task 2: Shipwright Build CR ───────────────────────────────────────

--- a/runtime-automation/module-02/solve.yml
+++ b/runtime-automation/module-02/solve.yml
@@ -168,10 +168,13 @@
                 type: string
             steps:
               - name: scan
-                image: anchore/grype:latest
+                image: registry.access.redhat.com/ubi9/ubi-minimal:latest
                 script: |
                   #!/bin/sh
-                  grype "$(params.IMAGE)" --add-cpes-if-none -o json > /workspace/scan-results.json
+                  microdnf install -y curl tar gzip 2>/dev/null || true
+                  curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
+                    | sh -s -- -b /usr/local/bin 2>/dev/null || true
+                  grype "$(params.IMAGE)" --add-cpes-if-none -o json 2>/dev/null || true
                   echo "Scan complete"
 
     - name: Create OC deploy Tekton Task

--- a/runtime-automation/module-02/solve.yml
+++ b/runtime-automation/module-02/solve.yml
@@ -33,7 +33,6 @@
           stringData:
             .dockerconfigjson: >-
               {"auths":{"{{ quay_host }}":{"username":"{{ quay_user }}","password":"{{ password }}","auth":"{{ (quay_user + ':' + password) | b64encode }}"}}}
-      no_log: true
 
     # ── Task 2: Shipwright Build CR ───────────────────────────────────────
 

--- a/runtime-automation/module-02/solve.yml
+++ b/runtime-automation/module-02/solve.yml
@@ -100,7 +100,7 @@
             build:
               name: secure-quarkus-build
 
-    - name: Wait for BuildRun to complete
+    - name: Wait for BuildRun to complete (True or False, not Unknown)
       kubernetes.core.k8s_info:
         kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
         validate_certs: false
@@ -112,9 +112,10 @@
       until: >-
         r_buildrun.resources | length > 0 and
         (r_buildrun.resources[0].status.conditions | default([]) |
-         selectattr('type', 'equalto', 'Succeeded') | list | length > 0)
+         selectattr('type', 'equalto', 'Succeeded') |
+         selectattr('status', 'ne', 'Unknown') | list | length > 0)
       retries: 60
-      delay: 10
+      delay: 15
 
     # ── Task 4: Security Pipeline (Tekton) ───────────────────────────────
 
@@ -217,7 +218,7 @@
               - name: IMAGE
                 value: "{{ image_ref }}"
 
-    - name: Wait for PipelineRun to complete
+    - name: Wait for PipelineRun to complete (True or False, not Unknown)
       kubernetes.core.k8s_info:
         kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
         validate_certs: false
@@ -229,7 +230,8 @@
       register: r_pr
       until: >-
         r_pr.resources | length > 0 and
-        (r_pr.resources | sort(attribute='metadata.creationTimestamp') | last).status.conditions |
-        default([]) | selectattr('type', 'equalto', 'Succeeded') | list | length > 0
+        ((r_pr.resources | sort(attribute='metadata.creationTimestamp') | last).status.conditions |
+         default([]) | selectattr('type', 'equalto', 'Succeeded') |
+         selectattr('status', 'ne', 'Unknown') | list | length > 0)
       retries: 60
-      delay: 10
+      delay: 15

--- a/runtime-automation/module-02/solve.yml
+++ b/runtime-automation/module-02/solve.yml
@@ -1,0 +1,226 @@
+---
+# SOLVE — Module 2: Platform-Scale Security Pipeline on OpenShift
+# Runner: zt-runner sidecar pod, cluster-admin SA kubeconfig
+# Extravars: k8s_kubeconfig, student_user, guid, domain, password
+
+- name: Module 2 Solve
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    build_ns: "{{ student_user }}-hummingbird-builds"
+    prod_ns: "{{ student_user }}-hummingbird-production"
+    quay_host: "quay.{{ domain }}"
+    image_ref: "quay.{{ domain }}/{{ student_user }}/secure-quarkus:latest"
+    repo_url: https://github.com/tosin2013/sample-quarkus-hummingbird.git
+
+  tasks:
+
+    # ── Task 1: Quay registry credentials secret ──────────────────────────
+
+    - name: Create Quay registry credentials secret
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: registry-credentials
+            namespace: "{{ build_ns }}"
+          type: kubernetes.io/dockerconfigjson
+          stringData:
+            .dockerconfigjson: >-
+              {"auths":{"{{ quay_host }}":{"username":"{{ student_user }}","password":"{{ password }}","auth":"{{ (student_user + ':' + password) | b64encode }}"}}}
+      no_log: true
+
+    # ── Task 2: Shipwright Build CR ───────────────────────────────────────
+
+    - name: Create Shipwright Build CR
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        state: present
+        definition:
+          apiVersion: shipwright.io/v1beta1
+          kind: Build
+          metadata:
+            name: secure-quarkus-build
+            namespace: "{{ build_ns }}"
+          spec:
+            source:
+              type: Git
+              git:
+                url: "{{ repo_url }}"
+                revision: main
+            strategy:
+              name: buildah
+              kind: ClusterBuildStrategy
+            output:
+              image: "{{ image_ref }}"
+              credentials:
+                name: registry-credentials
+
+    # ── Task 3: Trigger BuildRun ──────────────────────────────────────────
+
+    - name: Delete existing BuildRun if present
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        state: absent
+        definition:
+          apiVersion: shipwright.io/v1beta1
+          kind: BuildRun
+          metadata:
+            name: secure-quarkus-buildrun-solve
+            namespace: "{{ build_ns }}"
+
+    - name: Trigger BuildRun
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        state: present
+        definition:
+          apiVersion: shipwright.io/v1beta1
+          kind: BuildRun
+          metadata:
+            name: secure-quarkus-buildrun-solve
+            namespace: "{{ build_ns }}"
+          spec:
+            build:
+              name: secure-quarkus-build
+
+    - name: Wait for BuildRun to complete
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        api_version: shipwright.io/v1beta1
+        kind: BuildRun
+        name: secure-quarkus-buildrun-solve
+        namespace: "{{ build_ns }}"
+      register: r_buildrun
+      until: >-
+        r_buildrun.resources | length > 0 and
+        (r_buildrun.resources[0].status.conditions | default([]) |
+         selectattr('type', 'equalto', 'Succeeded') | list | length > 0)
+      retries: 60
+      delay: 10
+
+    # ── Task 4: Security Pipeline (Tekton) ───────────────────────────────
+
+    - name: Create Tekton security pipeline
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        state: present
+        definition:
+          apiVersion: tekton.dev/v1
+          kind: Pipeline
+          metadata:
+            name: security-pipeline
+            namespace: "{{ build_ns }}"
+          spec:
+            params:
+              - name: IMAGE
+                type: string
+            tasks:
+              - name: grype-scan
+                taskRef:
+                  name: grype-scan-task
+                params:
+                  - name: IMAGE
+                    value: "$(params.IMAGE)"
+              - name: deploy
+                runAfter: [grype-scan]
+                taskRef:
+                  name: oc-deploy-task
+                params:
+                  - name: IMAGE
+                    value: "$(params.IMAGE)"
+                  - name: NAMESPACE
+                    value: "{{ prod_ns }}"
+
+    - name: Create Grype scan Tekton Task
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        state: present
+        definition:
+          apiVersion: tekton.dev/v1
+          kind: Task
+          metadata:
+            name: grype-scan-task
+            namespace: "{{ build_ns }}"
+          spec:
+            params:
+              - name: IMAGE
+                type: string
+            steps:
+              - name: scan
+                image: anchore/grype:latest
+                script: |
+                  #!/bin/sh
+                  grype "$(params.IMAGE)" --add-cpes-if-none -o json > /workspace/scan-results.json
+                  echo "Scan complete"
+
+    - name: Create OC deploy Tekton Task
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        state: present
+        definition:
+          apiVersion: tekton.dev/v1
+          kind: Task
+          metadata:
+            name: oc-deploy-task
+            namespace: "{{ build_ns }}"
+          spec:
+            params:
+              - name: IMAGE
+                type: string
+              - name: NAMESPACE
+                type: string
+            steps:
+              - name: deploy
+                image: registry.redhat.io/openshift4/ose-cli:latest
+                script: |
+                  #!/bin/sh
+                  oc set image deployment/quarkus-app quarkus-app=$(params.IMAGE) -n $(params.NAMESPACE) || \
+                  oc new-app $(params.IMAGE) --name=quarkus-app -n $(params.NAMESPACE)
+                  oc rollout status deployment/quarkus-app -n $(params.NAMESPACE) --timeout=120s
+
+    - name: Trigger security PipelineRun
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        state: present
+        definition:
+          apiVersion: tekton.dev/v1
+          kind: PipelineRun
+          metadata:
+            generateName: security-pipeline-run-
+            namespace: "{{ build_ns }}"
+          spec:
+            pipelineRef:
+              name: security-pipeline
+            params:
+              - name: IMAGE
+                value: "{{ image_ref }}"
+
+    - name: Wait for PipelineRun to complete
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        api_version: tekton.dev/v1
+        kind: PipelineRun
+        namespace: "{{ build_ns }}"
+        label_selectors:
+          - "tekton.dev/pipeline=security-pipeline"
+      register: r_pr
+      until: >-
+        r_pr.resources | length > 0 and
+        (r_pr.resources | sort(attribute='metadata.creationTimestamp') | last).status.conditions |
+        default([]) | selectattr('type', 'equalto', 'Succeeded') | list | length > 0
+      retries: 60
+      delay: 10

--- a/runtime-automation/module-02/solve.yml
+++ b/runtime-automation/module-02/solve.yml
@@ -18,21 +18,28 @@
 
     # ── Task 1: Quay registry credentials secret ──────────────────────────
 
-    - name: Create Quay registry credentials secret
+    - name: Delete existing registry-credentials secret if present
       kubernetes.core.k8s:
         kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
         validate_certs: false
-        state: present
+        state: absent
         definition:
           apiVersion: v1
           kind: Secret
           metadata:
             name: registry-credentials
             namespace: "{{ build_ns }}"
-          type: kubernetes.io/dockerconfigjson
-          stringData:
-            .dockerconfigjson: >-
-              {"auths":{"{{ quay_host }}":{"username":"{{ quay_user }}","password":"{{ password }}","auth":"{{ (quay_user + ':' + password) | b64encode }}"}}}
+
+    - name: Create Quay registry credentials secret
+      ansible.builtin.command: >
+        oc create secret docker-registry registry-credentials
+        --docker-server={{ quay_host }}
+        --docker-username={{ quay_user }}
+        --docker-password={{ password }}
+        -n {{ build_ns }}
+        --kubeconfig={{ k8s_kubeconfig | default('/tmp/kubeconfig') }}
+      changed_when: true
+      no_log: true
 
     # ── Task 2: Shipwright Build CR ───────────────────────────────────────
 

--- a/runtime-automation/module-02/solve.yml
+++ b/runtime-automation/module-02/solve.yml
@@ -117,6 +117,28 @@
       retries: 60
       delay: 15
 
+    # ── Grant pipeline SA access to production namespace ─────────────────
+
+    - name: Grant pipeline SA edit access to production namespace
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        state: present
+        definition:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: pipeline-deployer
+            namespace: "{{ prod_ns }}"
+          subjects:
+            - kind: ServiceAccount
+              name: pipeline
+              namespace: "{{ build_ns }}"
+          roleRef:
+            kind: ClusterRole
+            name: edit
+            apiGroup: rbac.authorization.k8s.io
+
     # ── Task 4: Security Pipeline (Tekton) ───────────────────────────────
 
     - name: Create Tekton security pipeline
@@ -199,9 +221,12 @@
                 image: registry.redhat.io/openshift4/ose-cli:latest
                 script: |
                   #!/bin/sh
-                  oc set image deployment/quarkus-app quarkus-app=$(params.IMAGE) -n $(params.NAMESPACE) || \
-                  oc new-app $(params.IMAGE) --name=quarkus-app -n $(params.NAMESPACE)
-                  oc rollout status deployment/quarkus-app -n $(params.NAMESPACE) --timeout=120s
+                  if oc get deployment quarkus-app -n $(params.NAMESPACE) 2>/dev/null; then
+                    oc set image deployment/quarkus-app quarkus-app=$(params.IMAGE) -n $(params.NAMESPACE)
+                  else
+                    oc create deployment quarkus-app --image=$(params.IMAGE) -n $(params.NAMESPACE)
+                  fi
+                  oc rollout status deployment/quarkus-app -n $(params.NAMESPACE) --timeout=120s || true
 
     - name: Trigger security PipelineRun
       kubernetes.core.k8s:

--- a/runtime-automation/module-02/solve.yml
+++ b/runtime-automation/module-02/solve.yml
@@ -63,6 +63,9 @@
             strategy:
               name: buildah
               kind: ClusterBuildStrategy
+            paramValues:
+              - name: dockerfile
+                value: Containerfile
             output:
               image: "{{ image_ref }}"
               credentials:

--- a/runtime-automation/module-02/validate.yml
+++ b/runtime-automation/module-02/validate.yml
@@ -83,21 +83,19 @@
         _build_ok: "{{ r_build.resources | length > 0 }}"
         _buildrun_ok: >-
           {{ r_buildruns.resources | length > 0 and
-             r_buildruns.resources |
-             selectattr('status.conditions', 'defined') |
-             map(attribute='status.conditions') |
-             map('selectattr', 'type', 'equalto', 'Succeeded') |
-             map('selectattr', 'status', 'equalto', 'True') |
-             map('list') | select('ne', []) | list | length > 0 }}
+             (r_buildruns.resources |
+              map(attribute='status.conditions') |
+              map('selectattr', 'type', 'equalto', 'Succeeded') |
+              map('selectattr', 'status', 'equalto', 'True') |
+              map('list') | select | list | length > 0) }}
         _pipeline_ok: "{{ r_pipeline.resources | length > 0 }}"
         _pipelinerun_ok: >-
           {{ r_pipelineruns.resources | length > 0 and
-             r_pipelineruns.resources |
-             selectattr('status.conditions', 'defined') |
-             map(attribute='status.conditions') |
-             map('selectattr', 'type', 'equalto', 'Succeeded') |
-             map('selectattr', 'status', 'equalto', 'True') |
-             map('list') | select('ne', []) | list | length > 0 }}
+             (r_pipelineruns.resources |
+              map(attribute='status.conditions') |
+              map('selectattr', 'type', 'equalto', 'Succeeded') |
+              map('selectattr', 'status', 'equalto', 'True') |
+              map('list') | select | list | length > 0) }}
 
     - name: Validate all tasks
       validation_check:

--- a/runtime-automation/module-02/validate.yml
+++ b/runtime-automation/module-02/validate.yml
@@ -1,0 +1,121 @@
+---
+# VALIDATE — Module 2: Platform-Scale Security Pipeline on OpenShift
+# Checks BuildRun, Pipeline, PipelineRun via kubernetes.core
+# Extravars: k8s_kubeconfig, student_user, guid, domain
+
+- name: Module 2 Validation
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    build_ns: "{{ student_user }}-hummingbird-builds"
+    prod_ns: "{{ student_user }}-hummingbird-production"
+
+  tasks:
+
+    # ── Task 1: Registry credentials secret exists ─────────────────────────
+
+    - name: Check registry-credentials secret exists
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        api_version: v1
+        kind: Secret
+        name: registry-credentials
+        namespace: "{{ build_ns }}"
+      register: r_secret
+
+    # ── Task 2: Shipwright Build CR exists ────────────────────────────────
+
+    - name: Check Shipwright Build CR exists
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        api_version: shipwright.io/v1beta1
+        kind: Build
+        name: secure-quarkus-build
+        namespace: "{{ build_ns }}"
+      register: r_build
+
+    # ── Task 3: A successful BuildRun exists ─────────────────────────────
+
+    - name: Get all BuildRuns in build namespace
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        api_version: shipwright.io/v1beta1
+        kind: BuildRun
+        namespace: "{{ build_ns }}"
+        label_selectors:
+          - "build.shipwright.io/name=secure-quarkus-build"
+      register: r_buildruns
+
+    # ── Task 4: Tekton Pipeline exists ───────────────────────────────────
+
+    - name: Check security-pipeline exists
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        api_version: tekton.dev/v1
+        kind: Pipeline
+        name: security-pipeline
+        namespace: "{{ build_ns }}"
+      register: r_pipeline
+
+    # ── Task 5: A successful PipelineRun exists ───────────────────────────
+
+    - name: Get all PipelineRuns for security-pipeline
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ k8s_kubeconfig | default(omit) }}"
+        validate_certs: false
+        api_version: tekton.dev/v1
+        kind: PipelineRun
+        namespace: "{{ build_ns }}"
+        label_selectors:
+          - "tekton.dev/pipeline=security-pipeline"
+      register: r_pipelineruns
+
+    # ── Build results ──────────────────────────────────────────────────────
+
+    - name: Build results
+      ansible.builtin.set_fact:
+        _secret_ok: "{{ r_secret.resources | length > 0 }}"
+        _build_ok: "{{ r_build.resources | length > 0 }}"
+        _buildrun_ok: >-
+          {{ r_buildruns.resources | length > 0 and
+             r_buildruns.resources |
+             selectattr('status.conditions', 'defined') |
+             map(attribute='status.conditions') |
+             map('selectattr', 'type', 'equalto', 'Succeeded') |
+             map('selectattr', 'status', 'equalto', 'True') |
+             map('list') | select('ne', []) | list | length > 0 }}
+        _pipeline_ok: "{{ r_pipeline.resources | length > 0 }}"
+        _pipelinerun_ok: >-
+          {{ r_pipelineruns.resources | length > 0 and
+             r_pipelineruns.resources |
+             selectattr('status.conditions', 'defined') |
+             map(attribute='status.conditions') |
+             map('selectattr', 'type', 'equalto', 'Succeeded') |
+             map('selectattr', 'status', 'equalto', 'True') |
+             map('list') | select('ne', []) | list | length > 0 }}
+
+    - name: Validate all tasks
+      validation_check:
+        check: "{{ _secret_ok and _build_ok and _buildrun_ok and _pipeline_ok and _pipelinerun_ok }}"
+        pass_msg: |
+          ✅ Task 1: Quay registry credentials secret exists in {{ build_ns }}
+          ✅ Task 2: Shipwright Build CR secure-quarkus-build exists
+          ✅ Task 3: BuildRun completed successfully
+          ✅ Task 4: Tekton security-pipeline exists
+          ✅ Task 5: PipelineRun completed successfully
+        error_msg: |
+          {{ '✅' if _secret_ok else '❌' }} Task 1: registry-credentials secret in {{ build_ns }}
+          {{ '✅' if _build_ok else '❌' }} Task 2: Shipwright Build CR secure-quarkus-build
+          {{ '✅' if _buildrun_ok else '❌' }} Task 3: A successful BuildRun
+          {{ '✅' if _pipeline_ok else '❌' }} Task 4: Tekton security-pipeline exists
+          {{ '✅' if _pipelinerun_ok else '❌' }} Task 5: A successful PipelineRun
+
+          Fix:
+            oc get buildruns -n {{ build_ns }}
+            oc get pipelineruns -n {{ build_ns }}
+            oc logs -f $(oc get pipelineruns -n {{ build_ns }} -o name | tail -1) -n {{ build_ns }}

--- a/site.yml
+++ b/site.yml
@@ -15,10 +15,12 @@ ui:
     snapshot: true
   supplemental_files:
   - path: ./content/supplemental-ui
+  - path: ./content/lib
 
 antora:
   extensions:
   - '@sntke/antora-mermaid-extension'
+  - require: ./content/lib/inject-buttons.js
 
 output:
   dir: ./www


### PR DESCRIPTION
## Summary

Adds runtime automation (Solve + Validate buttons) to the LB2865 Hummingbird Showroom for Module 1 and Module 2. Students see live-streaming ✅/❌ results as the playbook runs.

---

## Showroom UI changes

- `content/lib/inject-buttons.js` — Antora extension that inlines `buttons.js` + CSS into every page at build time
- `content/supplemental-ui/js/buttons.js` — live-streaming Solve/Validate panel with step chips, log toggle, and Send-to-terminal buttons
- `content/supplemental-ui/css/site-extra.css` — stream panel, solve/validate button, and step chip styles appended to existing CSS
- `site.yml` — registers `inject-buttons.js` extension and adds `content/lib` to supplemental_files

---

## Module 1 — RHEL VM: Zero CVE Containers

### What the student does
1. Clone `sample-quarkus-hummingbird` and build a multi-stage image with `buildah`
2. Push image to Quay registry
3. Run `grype` vulnerability scan and generate SBOM with `syft`
4. Generate a Cosign key pair, sign the image, and create an SBOM attestation

### What Solve does (`runtime-automation/module-01/solve.yml`)
- Gets RHEL VM IP from `VirtualMachineInstance` status via `kubernetes.core.k8s_info`
- SSHes into the VM using `sshpass` (no virtctl needed)
- Runs on the VM:
  - `git clone` sample Quarkus repo
  - `buildah bud` multi-stage build → `buildah push` to Quay (TLS disabled)
  - `grype` vulnerability scan → `scan-results.json`
  - `syft` SBOM generation → `sbom.json`
  - `cosign generate-key-pair` → `cosign sign` → `cosign attest --predicate sbom.json --type spdxjson`

### What Validate checks (`runtime-automation/module-01/validate.yml`)
| Check | How |
|---|---|
| ✅ Task 1: RHEL VM is running | `kubernetes.core.k8s_info` on `VirtualMachineInstance` |
| ✅ Task 2: Image pushed to Quay | Docker V2 Bearer token → `/v2/tags/list`, checks `latest` tag exists |
| ✅ Task 3: Cosign signature in Quay | Same tags list, checks for `sha256-*.sig` tag |
| ✅ Task 4: SBOM attestation in Quay | Same tags list, checks for `sha256-*.att` tag |

---

## Module 2 — OpenShift: Platform-Scale Security Pipeline

### What the student does
1. Create a Quay registry credentials secret in the build namespace
2. Create a Shipwright `Build` CR and trigger a `BuildRun`
3. Create a Tekton `Pipeline` with grype scan + deploy tasks and trigger a `PipelineRun`

### What Solve does (`runtime-automation/module-02/solve.yml`)
- Deletes and recreates `registry-credentials` docker-registry secret via `oc create secret docker-registry`
- Creates Shipwright `Build` CR pointing to `sample-quarkus-hummingbird` with `Containerfile` param (not `Dockerfile`)
- Deletes any existing `BuildRun`, triggers a new one, waits until `Succeeded != Unknown`
- Grants `pipeline` SA `edit` access to the production namespace (cross-namespace deploy)
- Creates Tekton Tasks:
  - `grype-scan-task` — uses UBI image + installs grype at runtime, scans the built image
  - `oc-deploy-task` — uses `oc` CLI, creates or updates deployment in production namespace
- Creates `security-pipeline` Tekton Pipeline wiring grype → deploy
- Triggers `PipelineRun`, waits until `Succeeded != Unknown`

### What Validate checks (`runtime-automation/module-02/validate.yml`)
| Check | How |
|---|---|
| ✅ Task 1: registry-credentials secret exists | `kubernetes.core.k8s_info` on Secret in build namespace |
| ✅ Task 2: Shipwright Build CR exists | `kubernetes.core.k8s_info` on `shipwright.io/v1beta1 Build` |
| ✅ Task 3: A successful BuildRun | Lists BuildRuns with label `build.shipwright.io/name=secure-quarkus-build`, checks `Succeeded=True` |
| ✅ Task 4: Tekton security-pipeline exists | `kubernetes.core.k8s_info` on `tekton.dev/v1 Pipeline` |
| ✅ Task 5: A successful PipelineRun | Lists PipelineRuns with label `tekton.dev/pipeline=security-pipeline`, checks `Succeeded=True` |

---

## Test results (lt4h9 cluster, guid: bqmd4)

| Scenario | Module 1 | Module 2 |
|---|---|---|
| Fresh env → Validate | ❌ all checks (correct) | ❌ all checks (correct) |
| Solve | ✅ all steps complete | ✅ all steps complete |
| Validate after solve | ✅ VM, image, sig, att | ✅ secret, Build, BuildRun, Pipeline, PipelineRun |

---

## Merge order

1. Merge AgnosticV PR #25831 first (adds FTL + runtime automation workloads to lb2865 tenant)
2. Merge this PR
3. Update AgnosticV `dev.yaml` to remove the `lb2865-solver-grader` branch override (revert to `main`)