### PR TITLE
Fix Showroom content verification issues

### DIFF
--- a/content/antora.yml
+++ b/content/antora.yml
@@ -2,6 +2,7 @@
 name: modules
 title: "LB2865: Container Hardening: Zero to Hero with Red Hat Hardened Images"
 version: master
+start_page: index.adoc
 nav:
 - modules/ROOT/nav.adoc
 
@@ -10,6 +11,7 @@ asciidoc:
     # page-toclevels: -1               # <- This will remove the TOC that appear in the right sidebar at wider resolutions
     page-pagination: true
     workshop-title: "LB2865: Container Hardening: Zero to Hero with Red Hat Hardened Images"
+    lab_name: "LB2865: Container Hardening: Zero to Hero"
     workshop-duration: '90 minutes'
 
     weblab-duration: '15 minutes'

--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -6,10 +6,24 @@
 ** xref:module-01-03-scanning.adoc[1.3: Vulnerability Scanning & SBOMs]
 ** xref:module-01-04-signing.adoc[1.4: Image Signing & Attestation]
 ** xref:module-01-05-custom-security.adoc[1.5: Custom Security Configurations]
+** xref:module-01-06-selinux.adoc[1.6: SELinux Hardening with udica (Optional)]
+** xref:module-01-07-selinux-advanced.adoc[1.7: Advanced SELinux Hardening (Optional)]
+** xref:module-01-08-chunkah.adoc[1.8: Content-Based Layer Splitting with chunkah (Optional)]
+** xref:module-01-09-multi-lang-builds.adoc[1.9: Multi-Language Builds with Hummingbird (Optional)]
+** xref:module-01-10-chunkah-value.adoc[1.10: Demonstrating chunkah Value (Optional)]
+** xref:module-01-11-tomcat-hummingbird.adoc[1.11: Layering Tomcat on Hummingbird (Optional)]
 
 * Module 2: Shipwright and Buildpacks (OpenShift)
 ** xref:module-02-01-buildpacks.adoc[2.1: Building with Hummingbird]
-** xref:module-02-07-acs-zero-cve.adoc[2.2: Zero-CVE with ACS Enforcement]
+** xref:module-02-02-custom-strategies.adoc[2.2: Custom Multi-Language Strategies (Optional)]
+** xref:module-02-03-security-pipeline.adoc[2.3: Security Pipeline & Production Deployment (Optional)]
+** xref:module-02-04-tekton-udica.adoc[2.4: SELinux Policy CI/CD with Tekton (Optional)]
+** xref:module-02-05-chunkah-pipeline.adoc[2.5: chunkah in CI/CD Pipelines (Optional)]
+** xref:module-02-06-rhtas.adoc[2.6: Keyless Signing with RHTAS (Optional)]
+** xref:module-02-07-acs-zero-cve.adoc[2.7: Zero-CVE with ACS Enforcement]
+** xref:module-02-08-renovate-podman.adoc[2.8: Automated Dependency Updates with Renovate + Podman (Optional)]
+
+* xref:conclusion.adoc[Workshop Conclusion]
 
 * Appendix: Environment Setup
 ** xref:appendix-a-rhel-setup.adoc[Appendix A: RHEL Developer Environment]

--- a/content/modules/ROOT/pages/appendix-a-rhel-setup.adoc
+++ b/content/modules/ROOT/pages/appendix-a-rhel-setup.adoc
@@ -282,7 +282,7 @@ Complete!
 ====
 If a kernel update is installed, you may need to reboot your system before proceeding. Check with:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 sudo needs-restarting -r
 ----
@@ -587,7 +587,7 @@ Storing signatures
 * **User config**: `~/.config/containers/registries.conf` overrides system config for your user
 
 To view your active configuration:
-[source,bash]
+[source,bash,role=execute]
 ----
 podman info --format json | jq -r '.registries'
 ----
@@ -723,7 +723,7 @@ flatpak install --user -y flathub io.podman_desktop.PodmanDesktop
 ====
 `flatpak` is included in the RHEL 9 AppStream repository. If it is not already installed:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 sudo dnf install -y flatpak
 ----
@@ -789,7 +789,7 @@ If Podman Desktop doesn't detect your Podman socket, check that `systemctl --use
 
 Hummingbird images intentionally omit shells (`/bin/sh`, `/bin/bash`) to minimize attack surface. You cannot `exec` into them interactively. To debug a running Hummingbird container, use the sidecar pattern:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 podman run -it --rm \
   --pid=container:<container-name> \
@@ -808,7 +808,7 @@ This gives you a shell with access to the target container's PID and network nam
 === Troubleshooting
 
 **Issue: Podman socket not starting**
-[source,bash]
+[source,bash,role=execute]
 ----
 systemctl --user restart podman.socket
 systemctl --user status podman.socket
@@ -816,14 +816,14 @@ journalctl --user -u podman.socket -n 50
 ----
 
 **Issue: Registry authentication failures**
-[source,bash]
+[source,bash,role=execute]
 ----
 podman login quay.io
 podman login registry.access.redhat.com
 ----
 
 **Issue: Permission errors with rootless Podman**
-[source,bash]
+[source,bash,role=execute]
 ----
 grep "^$(whoami):" /etc/subuid /etc/subgid
 
@@ -834,7 +834,7 @@ loginctl terminate-user $(whoami)
 **Issue: Podman Desktop not detecting Podman**
 
 Ensure the Podman socket is active and listening:
-[source,bash]
+[source,bash,role=execute]
 ----
 systemctl --user status podman.socket
 ls -la /run/user/$(id -u)/podman/podman.sock
@@ -843,14 +843,14 @@ ls -la /run/user/$(id -u)/podman/podman.sock
 **Issue: Quarkus CLI not found after installation**
 
 Ensure JBang's bin directory is on your PATH:
-[source,bash]
+[source,bash,role=execute]
 ----
 export PATH="$HOME/.jbang/bin:$PATH"
 quarkus --version
 ----
 
 If JBang itself isn't installed, re-run the installation:
-[source,bash]
+[source,bash,role=execute]
 ----
 curl -Ls https://sh.jbang.dev | bash -s - trust add https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/
 curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force quarkus@quarkusio

--- a/content/modules/ROOT/pages/appendix-b-openshift-setup.adoc
+++ b/content/modules/ROOT/pages/appendix-b-openshift-setup.adoc
@@ -267,7 +267,7 @@ done
 ====
 If any operator stays in `Installing` phase for more than 5 minutes, check events in its namespace:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get events -n openshift-builds --sort-by=.metadata.creationTimestamp
 oc get events -n quay --sort-by=.metadata.creationTimestamp
@@ -312,7 +312,7 @@ Before starting the Module 2 labs, review the Shipwright resource hierarchy.
 **BuildStrategy** (Namespace-scoped)::
 Defines how to build images within a single namespace. Use for team-specific or experimental build patterns.
 +
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get buildstrategy -n hummingbird-builds-{user}
 ----
@@ -320,7 +320,7 @@ oc get buildstrategy -n hummingbird-builds-{user}
 **ClusterBuildStrategy** (Cluster-scoped)::
 Defines how to build images across the entire cluster. Use for organization-wide standards that all teams can leverage.
 +
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get clusterbuildstrategy
 ----
@@ -1320,7 +1320,7 @@ Your Gitea environment and Renovate build infrastructure are ready. Proceed to x
 === Troubleshooting
 
 **Issue: Operator stuck in Installing**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc logs -n openshift-builds -l name=openshift-builds-operator
 
@@ -1328,7 +1328,7 @@ oc get events -n openshift-builds --sort-by=.metadata.creationTimestamp
 ----
 
 **Issue: CRDs not appearing**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get csv -n openshift-builds
 
@@ -1336,7 +1336,7 @@ oc get pods -n openshift-builds
 ----
 
 **Issue: Permission denied creating ClusterBuildStrategy**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc auth can-i create clusterbuildstrategy
 
@@ -1344,7 +1344,7 @@ oc auth can-i '*' '*' --all-namespaces
 ----
 
 **Issue: Quay pods not starting**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get pods -n quay
 
@@ -1354,7 +1354,7 @@ oc get quayregistry -n quay -o yaml
 ----
 
 **Issue: ACS SecuredCluster stuck in Irreconcilable**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get securedcluster -n stackrox -o yaml
 
@@ -1364,7 +1364,7 @@ oc get secret sensor-tls -n stackrox
 If `sensor-tls` does not exist, the init bundle was not applied. Return to Step 20 to generate and apply it.
 
 **Issue: RHTAS operator not installing**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get csv -n trusted-artifact-signer
 
@@ -1372,7 +1372,7 @@ oc get events -n trusted-artifact-signer --sort-by=.metadata.creationTimestamp
 ----
 
 **Issue: RHTAS clientserver route not available**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get route -n trusted-artifact-signer
 
@@ -1382,7 +1382,7 @@ oc get pods -n trusted-artifact-signer
 The clientserver pod must be running before CLI tools can be downloaded. Wait for the operator to finish initialization.
 
 **Issue: Keycloak realm import failing**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get keycloakrealmimport trusted-artifact-signer -n keycloak -o yaml
 
@@ -1390,7 +1390,7 @@ oc logs -l app=keycloak -n keycloak --tail=50
 ----
 
 **Issue: Gitea operator not starting**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get pods -n gitea
 
@@ -1401,7 +1401,7 @@ oc get events -n gitea --sort-by=.metadata.creationTimestamp
 
 This happens when the ArgoCD Application is missing the `SkipDryRunOnMissingResource=true` sync option. ArgoCD validates all resources (including wave 10 Tekton Tasks/Pipelines) before applying any wave, and rejects resources whose CRDs have not yet been registered by the Pipelines operator (wave 1).
 
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get application hummingbird-workshop -n openshift-gitops \
   -o jsonpath='{.status.operationState.syncResult.resources}' | python3 -m json.tool
@@ -1409,14 +1409,14 @@ oc get application hummingbird-workshop -n openshift-gitops \
 
 Fix: ensure `SkipDryRunOnMissingResource=true` is present in the ArgoCD Application's `spec.syncPolicy.syncOptions`, then re-apply the application:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 # Re-run the bootstrap script to update the ArgoCD Application
 ./bootstrap/setup-all.sh
 ----
 
 **Issue: Gitea instance route not available**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get route -n gitea
 

--- a/content/modules/ROOT/pages/appendix-b-openshift-setup.adoc
+++ b/content/modules/ROOT/pages/appendix-b-openshift-setup.adoc
@@ -539,11 +539,11 @@ Click **Create Account** at the bottom of the login page and register with:
 * **Password:** `{quay_password}`
 * **Email:** `workshop@example.com`
 
-image::module-02/quay-create-account.png[Quay Create Account page,500,align="center"]
+image::module-02/quay-create-account.png[Quay Create Account page,500,align="center",link=self,window=blank]
 
 After creating the account you will be logged in and see the Repositories dashboard:
 
-image::module-02/quay-repositories-dashboard.png[Quay Repositories dashboard,700,align="center"]
+image::module-02/quay-repositories-dashboard.png[Quay Repositories dashboard,700,align="center",link=self,window=blank]
 ====
 
 ==== Step 14: Create Registry Credentials Secret

--- a/content/modules/ROOT/pages/conclusion.adoc
+++ b/content/modules/ROOT/pages/conclusion.adoc
@@ -1,0 +1,46 @@
+= Workshop Conclusion
+
+Congratulations on completing the {workshop-title} workshop! You have worked through the full lifecycle of building, hardening, and deploying container images using Red Hat Hardened Images and the OpenShift platform.
+
+== What You've Learned
+
+=== Module 1: Developer Environment (RHEL)
+
+In the first module you explored container hardening from a developer's workstation using Podman on RHEL:
+
+* Built minimal, distroless container images using Red Hat Hardened Images (Hummingbird)
+* Applied multi-stage build patterns to separate build-time dependencies from runtime
+* Scanned images for vulnerabilities and generated SBOMs for supply chain transparency
+* Signed container images and created attestations for provenance verification
+* Configured custom security profiles including FIPS mode and SELinux policies
+
+=== Module 2: Shipwright and Buildpacks (OpenShift)
+
+In the second module you moved to the OpenShift platform and automated the build and deployment pipeline:
+
+* Used Shipwright and Cloud Native Buildpacks to build images directly on OpenShift
+* Created custom build strategies for multi-language applications
+* Integrated security scanning and signing into CI/CD pipelines with Tekton
+* Enforced zero-CVE policies using Red Hat Advanced Cluster Security (ACS)
+
+== Key Takeaways
+
+* **Smaller images mean fewer vulnerabilities.** Red Hat Hardened Images eliminate unnecessary packages, reducing attack surface and CVE exposure to near zero at ship time.
+* **Supply chain security requires multiple layers.** Signing, attestation, SBOMs, and policy enforcement work together to establish trust from build to deployment.
+* **Automation is essential.** Shipwright and Tekton Pipelines bring container hardening practices into repeatable, auditable CI/CD workflows.
+* **Platform enforcement closes the loop.** ACS policies ensure that only verified, compliant images reach production, regardless of how they were built.
+
+== Next Steps
+
+* Explore additional Hummingbird base images for .NET, Python, Go, and database workloads
+* Integrate RHTAS (Red Hat Trusted Artifact Signer) for keyless signing in your own pipelines
+* Set up ACS policy enforcement across multiple clusters in your organization
+* Adopt chunkah for content-based layer splitting to optimize image pull times at scale
+
+== References
+
+* https://www.redhat.com/en/products/hardened-images[Red Hat Hardened Images (Hummingbird)^]
+* https://shipwright.io/docs[Shipwright Documentation^]
+* https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes[Red Hat Advanced Cluster Security Documentation^]
+* https://docs.redhat.com/en/documentation/red_hat_trusted_artifact_signer[Red Hat Trusted Artifact Signer Documentation^]
+* https://slsa.dev[SLSA Framework for Supply Chain Security^]

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -38,7 +38,7 @@ This module will introduce the new web application.
 
 In this hands-on module, you'll build and secure container images using a pre-configured developer environment:
 
-* **Multi-Stage Builds**: Build production images using various different types of harnded images
+* **Multi-Stage Builds**: Build production images using various different types of hardened images
 * **Size Optimization**: Compare image sizes and vulnerability counts
 * **Security Tools**: Use cosign, syft, and grype for image signing and scanning
 * **Security Workflow**: Scan for CVEs, generate SBOMs, sign and verify images
@@ -90,7 +90,7 @@ You will execute the first module in a Red Hat Enterprise Linux Virtual Machine 
 +
 [source,sh,subs=attributes,role=execute]
 ----
-oc login -u {user} -p {password} {openshift_api_url} --insecure-skip-tls-verify
+oc login -u {user} -p {password} {openshift_api_server_url} --insecure-skip-tls-verify
 ----
 
 . Switch to your OpenShift project:

--- a/content/modules/ROOT/pages/module-01-02-multi-stage.adoc
+++ b/content/modules/ROOT/pages/module-01-02-multi-stage.adoc
@@ -208,7 +208,7 @@ In xref:module-01-03-scanning.adoc[Sub-Module 1.3: Vulnerability Scanning & SBOM
 === Troubleshooting
 
 **Issue: Build fails with Maven dependency download errors**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Clear build cache and rebuild
 podman build --no-cache -t hummingbird-demo:v1 .
@@ -218,7 +218,7 @@ curl https://repo.maven.apache.org/maven2/
 ----
 
 **Issue: Image size larger than expected**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Verify multi-stage build is working
 podman history hummingbird-demo:v1
@@ -228,7 +228,7 @@ podman run --rm hummingbird-demo:v1 ls /build 2>/dev/null && echo "LEAK" || echo
 ----
 
 **Issue: Container fails to start**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Check logs for errors
 podman logs demo
@@ -241,7 +241,7 @@ podman run --rm hummingbird-demo:v1 java -version
 ----
 
 **Issue: Maven build fails inside the container**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Run builder stage interactively to debug
 podman run --rm -it {ubi-registry}/openjdk-21:latest bash

--- a/content/modules/ROOT/pages/module-01-03-scanning.adoc
+++ b/content/modules/ROOT/pages/module-01-03-scanning.adoc
@@ -301,7 +301,7 @@ In xref:module-01-04-signing.adoc[Sub-Module 1.4: Image Signing & Attestation], 
 === Troubleshooting
 
 **Issue: Grype database download fails**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Manually update database
 grype db update
@@ -311,7 +311,7 @@ grype db status
 ----
 
 **Issue: SBOM generation incomplete**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Try different output formats
 syft hummingbird-demo:v1 -o json=sbom-detailed.json
@@ -321,7 +321,7 @@ podman images | grep hummingbird-demo
 ----
 
 **Issue: Podman socket not available**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Restart podman socket
 systemctl --user restart podman.socket

--- a/content/modules/ROOT/pages/module-01-04-signing.adoc
+++ b/content/modules/ROOT/pages/module-01-04-signing.adoc
@@ -348,7 +348,7 @@ podman push $QUAY_ORG/hummingbird-demo:v1
 ----
 
 **Issue: Cosign verification fails**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Ensure you're using the correct public key and digest
 cosign verify --key cosign.pub --insecure-ignore-tlog=true ${QUAY_ORG}/hummingbird-demo@${IMAGE_DIGEST}
@@ -359,7 +359,7 @@ echo "Image digest: ${IMAGE_DIGEST}"
 ----
 
 **Issue: SBOM file not found for attestation**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Verify SBOM was generated in Sub-Module 1.3
 ls -la ~/scanning/hummingbird-demo.spdx

--- a/content/modules/ROOT/pages/module-01-05-custom-security.adoc
+++ b/content/modules/ROOT/pages/module-01-05-custom-security.adoc
@@ -359,7 +359,7 @@ Move to Module 2 to learn platform-level hardened image deployment with Shipwrig
 === Troubleshooting
 
 **Issue: Certificate verification still fails**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Verify the CA bundle was copied correctly
 podman run --rm curl:local-ca ls -la /etc/pki/ca-trust/extracted/
@@ -369,7 +369,7 @@ podman history curl:local-ca | grep "trust anchor"
 ----
 
 **Issue: FIPS image allows disallowed algorithms**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Verify you're using the -fips variant
 podman inspect fips:yes | grep -i fips
@@ -379,7 +379,7 @@ podman build --build-arg VARIANT=fips -t fips:yes -f ~/fips/Containerfile.fips ~
 ----
 
 **Issue: Caddy SSL server won't start**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Check Caddy logs
 podman logs caddy-ssl

--- a/content/modules/ROOT/pages/module-01-06-selinux.adoc
+++ b/content/modules/ROOT/pages/module-01-06-selinux.adoc
@@ -399,7 +399,7 @@ Move to Module 2 to learn platform-level hardened image deployment with Shipwrig
 === Troubleshooting
 
 **Issue: SELinux denials blocking container**
-[source,bash]
+[source,bash,role=execute]
 ----
 ausearch -m AVC -ts recent | grep denied
 
@@ -409,14 +409,14 @@ podman inspect container | udica --append-rules /var/log/audit/audit.log policy_
 ----
 
 **Issue: Policy won't load**
-[source,bash]
+[source,bash,role=execute]
 ----
 sudo semodule -r hummingbird_demo
 sudo semodule -i hummingbird_demo.cil /usr/share/udica/templates/*.cil
 ----
 
 **Issue: Container still using container_t**
-[source,bash]
+[source,bash,role=execute]
 ----
 podman inspect container | grep -i selinux
 

--- a/content/modules/ROOT/pages/module-01-07-selinux-advanced.adoc
+++ b/content/modules/ROOT/pages/module-01-07-selinux-advanced.adoc
@@ -399,20 +399,20 @@ Learn how to restructure Hummingbird image layers for optimal pull deduplication
 
 This occurs when re-running a container with `:Z` mounts after a previous container stamped MCS category labels on the directories. Force-reset the labels:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 sudo restorecon -FRv /opt/tomcat-app
 ----
 
 Also ensure the directories are owned by your user (not root) for rootless Podman:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 sudo chown -R $(id -u):$(id -g) /opt/tomcat-app
 ----
 
 **Issue: `--append-rules` produces empty policy**
-[source,bash]
+[source,bash,role=execute]
 ----
 ausearch -m AVC -ts recent | head -20
 
@@ -423,14 +423,14 @@ sudo systemctl restart auditd
 
 `udica` needs root access to query SELinux policy and read the audit log. Save inspect output first, then use `sudo`:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 podman inspect <container> > /tmp/inspect.json
 sudo udica --append-rules /var/log/audit/audit.log policy_name < /tmp/inspect.json
 ----
 
 **Issue: Device access still denied after policy load**
-[source,bash]
+[source,bash,role=execute]
 ----
 ausearch -m AVC -ts recent | grep denied | grep urandom
 
@@ -439,7 +439,7 @@ sudo udica --append-rules /var/log/audit/audit.log policy_v2 < /tmp/inspect.json
 ----
 
 **Issue: `semodule -r` fails (policy not found)**
-[source,bash]
+[source,bash,role=execute]
 ----
 sudo semodule -l | grep your_policy
 

--- a/content/modules/ROOT/pages/module-01-08-chunkah.adoc
+++ b/content/modules/ROOT/pages/module-01-08-chunkah.adoc
@@ -558,7 +558,7 @@ network traffic on every image update
 +
 Without squashing, your image has layers from each Containerfile instruction. chunkah works best starting from a single flat layer representing the complete final filesystem. Squashing first lets chunkah make all the layer decisions from scratch based on content, not build history.
 +
-[source,bash]
+[source,bash,role=execute]
 ----
 buildah build --squash-all -t my-app:flat .
 # Then run chunkah on the squashed image
@@ -582,7 +582,7 @@ chunkah understands RPM packages automatically but knows nothing about your appl
 +
 chunkah is a build-time optimisation (which layers change). `zstd:chunked` is a pull-time optimisation (how much of a changed layer to download). They stack -- always use both for production images:
 +
-[source,bash]
+[source,bash,role=execute]
 ----
 buildah push --compression-format zstd:chunked --compression-level 3 \
   my-app:latest docker://registry.example.com/apps/my-app:latest
@@ -592,7 +592,7 @@ buildah push --compression-format zstd:chunked --compression-level 3 \
 +
 chunkah is pre-1.0 and moving fast. Use a specific version tag, not `latest`:
 +
-[source,bash]
+[source,bash,role=execute]
 ----
 # Good
 podman run --rm quay.io/jlebon/chunkah:v0.2.0 build ...
@@ -646,7 +646,7 @@ rm -rf ~/hummingbird-lab/chunkah-demo/
 === Troubleshooting
 
 **Issue: chunkah container fails to start**
-[source,bash]
+[source,bash,role=execute]
 ----
 podman pull quay.io/jlebon/chunkah:latest
 
@@ -654,13 +654,13 @@ podman run --rm quay.io/jlebon/chunkah --help
 ----
 
 **Issue: `FROM oci-archive:` not found**
-[source,bash]
+[source,bash,role=execute]
 ----
 buildah build --skip-unused-stages=false ...
 ----
 
 **Issue: `Containerfile.splitter` download fails**
-[source,bash]
+[source,bash,role=execute]
 ----
 curl -LO https://github.com/jlebon/chunkah/releases/download/v0.2.0/Containerfile.splitter
 
@@ -673,7 +673,7 @@ buildah build \
 ----
 
 **Issue: xattr not supported**
-[source,bash]
+[source,bash,role=execute]
 ----
 sudo dnf install -y attr
 

--- a/content/modules/ROOT/pages/module-01-10-chunkah-value.adoc
+++ b/content/modules/ROOT/pages/module-01-10-chunkah-value.adoc
@@ -1,4 +1,4 @@
-= Sub-Module 1.20: The Aha Moment — Demonstrating chunkah Value (Optional)
+= Sub-Module 1.20: The Aha Moment -- Demonstrating chunkah Value (Optional)
 
 .*Sub-Module Overview*
 [sidebar]
@@ -540,7 +540,7 @@ podman inspect localhost/hummingbird-python-demo:latest \
 You will see the same pattern: RPM-based layers for the Hummingbird Python base, a `python-site-pkgs` layer for pip dependencies, and an `app-src` layer for your application code -- each independently cacheable and updateable.
 
 [[exercise-5-full-stack]]
-== Exercise 5: The Full Value Stack — chunkah + zstd:chunked
+== Exercise 5: The Full Value Stack -- chunkah + zstd:chunked
 
 This wraps everything together, showing how chunkah and `zstd:chunked` compound. Build it, split it, push it with `zstd:chunked`, then see what a node would actually download on an update.
 

--- a/content/modules/ROOT/pages/module-01-11-tomcat-hummingbird.adoc
+++ b/content/modules/ROOT/pages/module-01-11-tomcat-hummingbird.adoc
@@ -596,7 +596,7 @@ The WAR in this exercise uses `javax.servlet` to work with the RPM-provided Tomc
 === Troubleshooting
 
 **Issue: `microdnf install tomcat` fails in the builder**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Check available Tomcat packages
 podman run --rm --user root registry.access.redhat.com/ubi9/openjdk-21:latest \
@@ -604,7 +604,7 @@ podman run --rm --user root registry.access.redhat.com/ubi9/openjdk-21:latest \
 ----
 
 **Issue: Tomcat fails to start with permission errors**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Check the user and directory ownership
 podman run --rm localhost/my-tomcat-app:v1 ls -la /opt/tomcat/logs
@@ -612,7 +612,7 @@ podman run --rm localhost/my-tomcat-app:v1 id
 ----
 
 **Issue: WAR not deploying (404 on `/app/`)**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Check the webapps directory
 podman run --rm localhost/my-tomcat-app:v1 ls /opt/tomcat/webapps/
@@ -622,7 +622,7 @@ podman logs tomcat-test
 ----
 
 **Issue: `ClassNotFoundException` for servlet classes**
-[source,bash]
+[source,bash,role=execute]
 ----
 # This means your WAR's servlet API version doesn't match the Tomcat version.
 # Tomcat 9 (RPM) uses javax.servlet; Tomcat 10 uses jakarta.servlet.

--- a/content/modules/ROOT/pages/module-02-01-buildpacks.adoc
+++ b/content/modules/ROOT/pages/module-02-01-buildpacks.adoc
@@ -386,12 +386,12 @@ The image labels from the Hummingbird base image (e.g., `io.hummingbird-project.
 Open the Quay console and navigate to **Repositories** -> **workshopuser/sample-quarkus**. You should see the `latest` tag with a successful security scan:
 
 .Quay repository showing the pushed sample-quarkus:latest image
-image::module-02/quay-sample-quarkus-tags.png[Quay Repository Tags,width=800]
+image::module-02/quay-sample-quarkus-tags.png[Quay Repository Tags,width=800,link=self,window=blank]
 
 Click the security scan result to view the Clair vulnerability report. A Hummingbird-based image should show **zero vulnerabilities**:
 
 .Clair security scan: zero CVEs detected in the Hummingbird runtime image
-image::module-02/quay-clair-zero-cve.png[Clair Zero CVE Scan,width=800]
+image::module-02/quay-clair-zero-cve.png[Clair Zero CVE Scan,width=800,link=self,window=blank]
 
 [[deploy-application]]
 == Deploy Built Image
@@ -444,7 +444,7 @@ Application URL: http://sample-quarkus-hummingbird-builds.apps.<cluster-domain>/
 You can also open the URL in your browser by navigating to `http://<route>/hello`:
 
 .Browser showing the Hummingbird Quarkus /hello endpoint response
-image::module-02/quarkus-hello-endpoint.png[Quarkus Hello Endpoint,width=800]
+image::module-02/quarkus-hello-endpoint.png[Quarkus Hello Endpoint,width=800,link=self,window=blank]
 
 Also verify the Quarkus health endpoint:
 
@@ -465,7 +465,7 @@ curl -s http://$ROUTE/q/health | python3 -m json.tool
 ====
 If you get a timeout, the application may still be starting. Check pod status:
 
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get pods -l app=sample-quarkus -n hummingbird-builds-{user}
 oc logs -l app=sample-quarkus -n hummingbird-builds-{user}
@@ -473,7 +473,7 @@ oc logs -l app=sample-quarkus -n hummingbird-builds-{user}
 ====
 
 .OpenShift console: hummingbird-builds pods showing the completed build and running application
-image::module-02/openshift-hummingbird-builds-pods.png[OpenShift Pods,width=800]
+image::module-02/openshift-hummingbird-builds-pods.png[OpenShift Pods,width=800,link=self,window=blank]
 
 [IMPORTANT]
 ====
@@ -590,7 +590,7 @@ Looking for additional depth? The following optional sub-modules extend the work
 === Troubleshooting
 
 **Issue: BuildRun fails with registry push error**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get secret registry-credentials -n hummingbird-builds-{user}
 oc describe sa pipeline -n hummingbird-builds-{user} | grep registry-credentials
@@ -606,7 +606,7 @@ oc secrets link pipeline registry-credentials -n hummingbird-builds-{user}
 ----
 
 **Issue: BuildRun stuck in Pending**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get pods -n openshift-pipelines
 oc get events -n hummingbird-builds-{user} --sort-by=.metadata.creationTimestamp
@@ -617,7 +617,7 @@ oc describe buildrun sample-quarkus-app-run-1 -n hummingbird-builds-{user}
 
 This typically indicates a problem with the NooBaa object storage backend used by Quay:
 
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get backingstore -n openshift-storage
 oc get noobaa -n openshift-storage -o jsonpath='{.items[0].status.phase}'
@@ -632,7 +632,7 @@ oc delete buildrun sample-quarkus-app-run-1 -n hummingbird-builds-{user}
 
 The Maven wrapper script must be executable in the Git repository. If you see this error, ensure the repo has the correct permissions:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 # On the machine where the repo is managed:
 chmod +x mvnw
@@ -645,14 +645,14 @@ git push
 
 The on-cluster Quay registry creates repositories as **private** by default. The `default` ServiceAccount needs pull credentials:
 
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc secrets link default registry-credentials --for=pull -n hummingbird-builds-{user}
 oc delete pod -l app=sample-quarkus -n hummingbird-builds-{user}
 ----
 
 **Issue: Application not responding**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get pods -l app=sample-quarkus -n hummingbird-builds-{user}
 oc logs -l app=sample-quarkus -n hummingbird-builds-{user}

--- a/content/modules/ROOT/pages/module-02-02-custom-strategies.adoc
+++ b/content/modules/ROOT/pages/module-02-02-custom-strategies.adoc
@@ -588,7 +588,7 @@ Integrate SBOM generation, vulnerability scanning, image signing, and production
 === Troubleshooting
 
 **Issue: Language detection fails**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Check detect-and-generate step logs
 BUILDRUN_POD=$(oc get buildrun <buildrun-name> -o jsonpath='{.status.taskRunName}')-pod
@@ -599,7 +599,7 @@ oc logs $BUILDRUN_POD -c step-detect-and-generate
 ----
 
 **Issue: Buildah build fails**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Check build-and-push step logs for errors
 oc logs $BUILDRUN_POD -c step-build-and-push
@@ -611,7 +611,7 @@ oc logs $BUILDRUN_POD -c step-build-and-push
 ----
 
 **Issue: Internal registry not accessible**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Verify registry route exists
 oc get route default-route -n openshift-image-registry

--- a/content/modules/ROOT/pages/module-02-02-custom-strategies.adoc
+++ b/content/modules/ROOT/pages/module-02-02-custom-strategies.adoc
@@ -472,7 +472,7 @@ sample-app   image-registry.openshift-image-registry.svc:5000/hummingbird-builds
 You can also verify this in the OpenShift console under **Builds** -> **ImageStreams** in the `hummingbird-builds-{user}` project:
 
 .OpenShift console showing the sample-app ImageStream created by the internal registry build
-image::module-02/openshift-imagestream-sample-app.png[OpenShift ImageStreams,width=800]
+image::module-02/openshift-imagestream-sample-app.png[OpenShift ImageStreams,width=800,link=self,window=blank]
 
 [[air-gap-registry-mirrors]]
 == Air-Gapped Registry Mirrors

--- a/content/modules/ROOT/pages/module-02-03-security-pipeline.adoc
+++ b/content/modules/ROOT/pages/module-02-03-security-pipeline.adoc
@@ -313,12 +313,12 @@ Using both gives you immediate feedback in the pipeline _and_ continuous monitor
 You can also verify the results visually in the Quay console. Navigate to **Repositories** -> **{quay_user}/secure-nodejs**:
 
 .Quay repository showing the secure-nodejs:latest image with a passed security scan
-image::module-02/quay-secure-nodejs-tags.png[Quay Secure Node.js Tags,width=800]
+image::module-02/quay-secure-nodejs-tags.png[Quay Secure Node.js Tags,width=800,link=self,window=blank]
 
 Click the security scan result to view the Clair vulnerability report. A Hummingbird-based image should show zero vulnerabilities:
 
 .Clair security scan: zero CVEs detected in the secure-nodejs Hummingbird image
-image::module-02/quay-secure-nodejs-clair-zero-cve.png[Clair Zero CVE Scan,width=800]
+image::module-02/quay-secure-nodejs-clair-zero-cve.png[Clair Zero CVE Scan,width=800,link=self,window=blank]
 
 [[production-deployment]]
 == Production Deployment
@@ -461,7 +461,7 @@ production-app-ghi789-rst        1/1     Running   0          30s
 ----
 
 .OpenShift console: three production-app replicas running in hummingbird-production
-image::module-02/openshift-production-pods.png[Production Pods,width=800]
+image::module-02/openshift-production-pods.png[Production Pods,width=800,link=self,window=blank]
 
 === Step 9: Get Application Route
 
@@ -634,7 +634,7 @@ Create Tekton Tasks that generate udica policies alongside image builds, deploy 
 === Troubleshooting
 
 **Issue: SBOM generation fails**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 # Check syft step logs
 oc logs ${TASKRUN}-pod -n hummingbird-builds-{user} -c step-generate-sbom
@@ -644,7 +644,7 @@ podman pull <image>
 ----
 
 **Issue: Vulnerability scan fails build**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 # View scan results
 oc logs ${TASKRUN}-pod -n hummingbird-builds-{user} -c step-scan-vulnerabilities
@@ -656,7 +656,7 @@ grype <image> --only-fixed
 ----
 
 **Issue: Clair scan status shows "queued" or "unsupported"**
-[source,bash,subs="attributes"]
+[source,bash,role=execute,subs="attributes"]
 ----
 # Verify Clair is running
 oc get pods -n {quay-namespace} -l quay-component=clair-app
@@ -668,7 +668,7 @@ oc logs -n {quay-namespace} -l quay-component=clair-app --tail=50
 ----
 
 **Issue: Production deployment CrashLoopBackOff**
-[source,bash]
+[source,bash,role=execute]
 ----
 # Check pod logs
 oc logs -l app=production-app -n hummingbird-production

--- a/content/modules/ROOT/pages/module-02-03-security-pipeline.adoc
+++ b/content/modules/ROOT/pages/module-02-03-security-pipeline.adoc
@@ -484,7 +484,7 @@ curl -sk https://$ROUTE
 ----
 
 .Production app JSON response showing Node.js version details
-image::module-02/production-app-response.png[Production App Response,width=400]
+image::module-02/production-app-response.png[Production App Response,width=400,link=self,window=blank]
 
 [TIP]
 ====

--- a/content/modules/ROOT/pages/module-02-04-tekton-udica.adoc
+++ b/content/modules/ROOT/pages/module-02-04-tekton-udica.adoc
@@ -217,7 +217,7 @@ Generate a policy for the Node.js application built in Sub-Module 2.3:
 ====
 The `udica-policy-generate` Task runs `podman` inside the step, which requires the `privileged` SCC. The workshop bootstrap pre-configures this automatically. If you are running outside the bootstrapped environment, grant it manually:
 
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc adm policy add-scc-to-user privileged -z pipeline -n hummingbird-builds-{user}
 ----
@@ -329,7 +329,7 @@ Once the CIL policy is loaded on cluster nodes (via MachineConfig or manually), 
 ====
 The `seLinuxOptions.type` field requires an SCC that allows custom SELinux types. The default `restricted-v2` SCC rejects it. The workshop bootstrap pre-configures the `privileged` SCC for the `default` service account automatically. If you are running outside the bootstrapped environment, grant it manually:
 
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc adm policy add-scc-to-user privileged -z default -n hummingbird-builds-{user}
 ----
@@ -503,7 +503,7 @@ A working reference implementation of this structure is available at https://git
 
 === load-policy.sh Helper
 
-[source,bash]
+[source,bash,role=execute]
 ----
 #!/bin/bash
 set -euo pipefail
@@ -610,7 +610,7 @@ Prove the zero-CVE posture by deploying a legacy vulnerable image alongside a Hu
 === Troubleshooting
 
 **Issue: TaskRun fails with permission errors**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get taskrun generate-nodejs-policy -o yaml | grep -A5 status
 
@@ -618,7 +618,7 @@ oc adm policy add-scc-to-user privileged -z pipeline -n hummingbird-builds-{user
 ----
 
 **Issue: SELinux type not found on node**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc debug node/<node-name> -- chroot /host semodule -l | grep hummingbird
 
@@ -627,7 +627,7 @@ oc get machineconfigpool worker
 ----
 
 **Issue: MachineConfig not rolling out**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get machineconfigpool worker -o yaml | grep -A10 status
 

--- a/content/modules/ROOT/pages/module-02-04-tekton-udica.adoc
+++ b/content/modules/ROOT/pages/module-02-04-tekton-udica.adoc
@@ -258,7 +258,7 @@ Wait until the STATUS shows `True` (Succeeded), then press `Ctrl+C`.
 You can also watch the PipelineRun in the OpenShift console under **Pipelines -> PipelineRuns** in the `hummingbird-builds-{user}` namespace:
 
 .OpenShift console: generate-nodejs-policy PipelineRun succeeded with udica policy generation logs
-image::module-02/openshift-pipelinerun-selinux.png[PipelineRun SELinux,width=800]
+image::module-02/openshift-pipelinerun-selinux.png[PipelineRun SELinux,width=800,link=self,window=blank]
 
 === Step 7: View the Generated Policy
 

--- a/content/modules/ROOT/pages/module-02-05-chunkah-pipeline.adoc
+++ b/content/modules/ROOT/pages/module-02-05-chunkah-pipeline.adoc
@@ -497,7 +497,7 @@ As of chunkah v0.2.0:
 === Troubleshooting
 
 **Issue: TaskRun fails with permission errors**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get taskrun chunkah-split-nodejs -o yaml | grep -A5 status
 
@@ -505,7 +505,7 @@ oc adm policy add-scc-to-user privileged -z pipeline -n hummingbird-builds-{user
 ----
 
 **Issue: chunkah image pull fails in cluster**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get pods -n hummingbird-builds-{user}
 
@@ -513,7 +513,7 @@ podman pull quay.io/jlebon/chunkah:v0.2.0
 ----
 
 **Issue: zstd:chunked push fails**
-[source,bash]
+[source,bash,role=execute]
 ----
 podman --version
 

--- a/content/modules/ROOT/pages/module-02-06-rhtas.adoc
+++ b/content/modules/ROOT/pages/module-02-06-rhtas.adoc
@@ -1023,14 +1023,14 @@ Managing private keys is difficult, revoking them in a controlled fashion even m
 === Troubleshooting
 
 **Issue: Securesign components not reaching Ready**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc describe securesign securesign-sample -n trusted-artifact-signer
 oc get events -n trusted-artifact-signer --sort-by=.metadata.creationTimestamp
 ----
 
 **Issue: Fulcio rejects the OIDC token**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 oc get sa rhtas-signer -n hummingbird-builds-{user} -o yaml
 
@@ -1038,7 +1038,7 @@ oc logs -l app.kubernetes.io/component=fulcio -n trusted-artifact-signer
 ----
 
 **Issue: cosign sign fails with certificate errors**
-[source,bash,subs=attributes]
+[source,bash,role=execute,subs=attributes]
 ----
 cosign initialize --mirror="$TUF_URL" --root="$TUF_URL/root.json"
 
@@ -1046,7 +1046,7 @@ oc get configmap rhtas-config -n hummingbird-builds-{user} -o yaml
 ----
 
 **Issue: Conforma reports violations**
-[source,bash]
+[source,bash,role=execute]
 ----
 ec validate image \
   --image "$IMAGE" \

--- a/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
+++ b/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
@@ -428,7 +428,7 @@ echo "WORKSHOP_REGISTRY=${WORKSHOP_REGISTRY}"
 echo "REGISTRY_USER=${REGISTRY_USER}"
 ----
 
-If either line prints blank or `{quay_hostname}` / `{quay_user}` literally, your shell session has reset. Re-run *Step 2* completely before continuing — otherwise the build will push to an invalid image reference and the deployment will fail with `InvalidImageName`.
+If either line prints blank or `{quay_hostname}` / `{quay_user}` literally, your shell session has reset. Re-run *Step 2* completely before continuing -- otherwise the build will push to an invalid image reference and the deployment will fail with `InvalidImageName`.
 ====
 
 [source,bash,role=execute,subs="attributes"]
@@ -462,11 +462,11 @@ rm -f Dockerfile
 
 Verify the image appears in Quay with its security scan:
 
-image::module-02/legacy-python-quay-tags.png[Quay Repository Tags for legacy-python-api]
+image::module-02/legacy-python-quay-tags.png[Quay Repository Tags for legacy-python-api,link=self,window=blank]
 
 Click on the security scan column to view the CVE details. The `python:3.11-buster` base image carries multiple fixable vulnerabilities:
 
-image::module-02/legacy-python-cve-scan.png[Clair Security Scan showing 10 fixable vulnerabilities in legacy-python-api]
+image::module-02/legacy-python-cve-scan.png[Clair Security Scan showing 10 fixable vulnerabilities in legacy-python-api,link=self,window=blank]
 
 === Step 5: Deploy to OpenShift
 
@@ -649,11 +649,11 @@ Log in to the ACS Central dashboard:
 . Accept the self-signed certificate warning if prompted
 . Select *Login with username/password* and log in with username `admin` and the password shown above
 
-image::module-02/acs-login.png[ACS Central Login Page]
+image::module-02/acs-login.png[ACS Central Login Page,link=self,window=blank]
 
 After logging in, you will see the ACS Dashboard showing cluster-wide security metrics -- policy violations, images at most risk, and deployments at most risk:
 
-image::module-02/acs-dashboard.png[ACS Central Dashboard showing security overview]
+image::module-02/acs-dashboard.png[ACS Central Dashboard showing security overview,link=self,window=blank]
 
 Now navigate to the legacy image vulnerabilities:
 
@@ -661,11 +661,11 @@ Now navigate to the legacy image vulnerabilities:
 . Search for `legacy-python-api` in the Image Name filter
 . You will see **60 CVEs** across the image, including critical and high severity findings:
 
-image::module-02/acs-legacy-cves-all.png[ACS Vulnerability findings showing 60 CVEs in legacy-python-api]
+image::module-02/acs-legacy-cves-all.png[ACS Vulnerability findings showing 60 CVEs in legacy-python-api,link=self,window=blank]
 
 Filter to show only **fixable Critical and Important** CVEs to see the most actionable findings:
 
-image::module-02/acs-legacy-cves-fixable.png[ACS filtered view showing 3 fixable Critical/Important CVEs]
+image::module-02/acs-legacy-cves-fixable.png[ACS filtered view showing 3 fixable Critical/Important CVEs,link=self,window=blank]
 
 [NOTE]
 ====
@@ -765,11 +765,11 @@ rm -f Dockerfile
 
 Verify the fortress image in Quay. Notice the `zero-cve` tag with a **Passed** security scan and a dramatically smaller size (38 MB vs 339 MB):
 
-image::module-02/fortress-quay-tags.png[Quay Repository Tags for fortress-python-api showing Passed security scan]
+image::module-02/fortress-quay-tags.png[Quay Repository Tags for fortress-python-api showing Passed security scan,link=self,window=blank]
 
 Click the security scan to confirm -- **zero vulnerabilities detected**:
 
-image::module-02/fortress-zero-cve-scan.png[Clair Security Scanner showing no vulnerabilities in fortress-python-api]
+image::module-02/fortress-zero-cve-scan.png[Clair Security Scanner showing no vulnerabilities in fortress-python-api,link=self,window=blank]
 
 === Step 3: Compare Image Sizes
 
@@ -933,7 +933,7 @@ This shows three types of supply chain artifacts attached to the image:
 ====
 If `cosign tree` is not available, you can fall back to `skopeo`:
 
-[source,bash,subs="attributes"]
+[source,bash,role=execute,subs="attributes"]
 ----
 skopeo inspect --raw docker://{hummingbird-registry}/python:latest | \
   python3 acs-inspect-provenance.py
@@ -1066,7 +1066,7 @@ Scan results for image: .../fortress-python-api:zero-cve
 
 Verify in the ACS dashboard -- search for `fortress-python-api:zero-cve` under *Vulnerability Management* -> *Results*. You should see **0 CVEs, 0 Images affected**:
 
-image::module-02/acs-fortress-zero-cve.png[ACS Vulnerability Management showing zero CVEs for fortress-python-api:zero-cve]
+image::module-02/acs-fortress-zero-cve.png[ACS Vulnerability Management showing zero CVEs for fortress-python-api:zero-cve,link=self,window=blank]
 
 [source,bash,role=execute]
 ----
@@ -1182,11 +1182,11 @@ If the policies already exist, the script ensures enforcement is enabled (`SCALE
 
 Verify in the ACS dashboard under *Platform Configuration* -> *Policy Management*. Search for your policy name:
 
-image::module-02/acs-policy-zero-cve-list.png[ACS Policy Management showing Zero Fixable CVEs Required policy with Critical severity]
+image::module-02/acs-policy-zero-cve-list.png[ACS Policy Management showing Zero Fixable CVEs Required policy with Critical severity,link=self,window=blank]
 
 Click the policy to see its details -- severity, description, lifecycle stage, and enforcement action:
 
-image::module-02/acs-policy-zero-cve-detail.png[ACS Policy detail view for Zero Fixable CVEs Required showing Critical severity and Deploy lifecycle]
+image::module-02/acs-policy-zero-cve-detail.png[ACS Policy detail view for Zero Fixable CVEs Required showing Critical severity and Deploy lifecycle,link=self,window=blank]
 
 [IMPORTANT]
 ====
@@ -1429,15 +1429,15 @@ Policy: Zero Fixable CVEs Required - <your-user>
 
 You can also view violations visually in the ACS Central UI. Navigate to *Violations* in the left sidebar:
 
-image::module-02/acs-violations-list.png[ACS Violations list showing 108 results including Zero Fixable CVEs Required enforced on legacy-python-api]
+image::module-02/acs-violations-list.png[ACS Violations list showing 108 results including Zero Fixable CVEs Required enforced on legacy-python-api,link=self,window=blank]
 
 Click on your *Zero Fixable CVEs Required* violation to see the individual CVEs that triggered it:
 
-image::module-02/acs-violation-cves.png[Violation detail showing fixable CVEs in mercurial pip and setuptools components]
+image::module-02/acs-violation-cves.png[Violation detail showing fixable CVEs in mercurial pip and setuptools components,link=self,window=blank]
 
 Switch to the *Enforcement* tab to see the enforcement action taken:
 
-image::module-02/acs-violation-enforcement.png[Enforcement tab showing deployment scaled to 0 replicas in response to policy violation]
+image::module-02/acs-violation-enforcement.png[Enforcement tab showing deployment scaled to 0 replicas in response to policy violation,link=self,window=blank]
 
 [IMPORTANT]
 ====
@@ -1559,14 +1559,14 @@ The operational mindset shifts from "how fast can we patch?" to "there is nothin
 === Troubleshooting
 
 **Issue: roxctl cannot reach ACS Central**
-[source,bash]
+[source,bash,role=execute]
 ----
 curl -sk https://$ROX_ENDPOINT/v1/metadata
 oc get route -n stackrox
 ----
 
 **Issue: Admission controller not blocking deployments**
-[source,bash]
+[source,bash,role=execute]
 ----
 oc get ValidatingWebhookConfiguration -l app.kubernetes.io/name=stackrox -o yaml
 
@@ -1574,7 +1574,7 @@ oc logs -n stackrox deploy/admission-control
 ----
 
 **Issue: Policy not triggering on deployment**
-[source,bash,subs="attributes"]
+[source,bash,role=execute,subs="attributes"]
 ----
 ACS_ROUTE=$(oc get route central -n {acs-namespace} -o jsonpath='{.spec.host}')
 curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" \

--- a/content/modules/ROOT/pages/module-02-08-renovate-podman.adoc
+++ b/content/modules/ROOT/pages/module-02-08-renovate-podman.adoc
@@ -68,7 +68,7 @@ Part 3: Tekton EventListener for Renovate PRs (~8 min)
   -> CEL-filtered triggers for PR opened and PR merged
 
 Part 4: Full Build Pipeline with Buildah + Skopeo (~10 min)
-  -> Clone, build, scan, SBOM, sign, promote — all Podman-native
+  -> Clone, build, scan, SBOM, sign, promote -- all Podman-native
 
 Part 5: Testing the Full Loop Locally with Podman (~5 min)
   -> Simulate the entire pipeline on your workstation
@@ -1350,7 +1350,7 @@ echo "Full loop validated locally"
 ====
 Make sure you have generated a cosign key pair before running the sign/verify steps:
 
-[source,bash]
+[source,bash,role=execute]
 ----
 mkdir -p ~/.config/containers/signing
 cd ~/.config/containers/signing

--- a/site.yml
+++ b/site.yml
@@ -3,6 +3,9 @@ site:
   title: 'LB2865 Container Hardening: Zero to Hero'
   start_page: modules::index.adoc
 
+runtime:
+  fetch: true
+
 content:
   sources:
   - url: .


### PR DESCRIPTION
## Summary

- **Scaffold fixes**: Added `start_page` and `lab_name` to `antora.yml`, `runtime.fetch` to `site.yml`
- **Navigation**: Added 12 missing optional modules to `nav.adoc` with proper numbering
- **Conclusion module**: Created `conclusion.adoc` with consolidated references, key takeaways, and next steps
- **Code blocks**: Added `role=execute` to 89 `[source,bash]` blocks across 18 files so Showroom renders copy/execute buttons
- **Attribute fix**: Corrected `{openshift_api_url}` to `{openshift_api_server_url}` in `index.adoc`
- **Typo fix**: "harnded" → "hardened" in `index.adoc`
- **Em dashes**: Replaced 4 prose em dashes with double dashes per Red Hat style guide

## Test plan

- [ ] Run `antora --fetch site.yml` locally and verify site builds without errors
- [ ] Verify all 22 module pages appear in the left nav
- [ ] Confirm `conclusion.adoc` renders correctly with external links opening in new tabs
- [ ] Spot-check troubleshooting sections for copy/execute buttons in Showroom

🤖 Generated with [Claude Code](https://claude.com/claude-code)