### PR TITLE
fix(module-02-07, module-02-01): ACS login fixes, CVE blog references, Hummingbird image link updates, and Python Trixie migration

### DIFF
--- a/.github/workflows/mirror-python-images.yml
+++ b/.github/workflows/mirror-python-images.yml
@@ -15,12 +15,12 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq skopeo
 
-      - name: Mirror python:3.11-buster
+      - name: Mirror python:3.11-trixie
         run: |
           skopeo copy \
             --dest-creds="${{ secrets.QUAY_ROBOT_USER }}:${{ secrets.QUAY_ROBOT_TOKEN }}" \
-            docker://docker.io/library/python:3.11-buster \
-            docker://quay.io/takinosh/python3.11-buster:latest
+            docker://docker.io/library/python:3.11-trixie \
+            docker://quay.io/takinosh/python3.11-trixie:latest
 
       - name: Mirror python:3.11-slim
         run: |
@@ -31,5 +31,5 @@ jobs:
 
       - name: Verify mirrors
         run: |
-          skopeo inspect docker://quay.io/takinosh/python3.11-buster:latest | jq '{Digest, Created}'
+          skopeo inspect docker://quay.io/takinosh/python3.11-trixie:latest | jq '{Digest, Created}'
           skopeo inspect docker://quay.io/takinosh/python3.11-slim:latest | jq '{Digest, Created}'

--- a/content/antora.yml
+++ b/content/antora.yml
@@ -39,6 +39,8 @@ asciidoc:
     #hummingbird-registry: 'registry.access.redhat.com/hi'
     hummingbird-registry: 'registry.access.redhat.com/hi'
     ubi-registry: 'registry.access.redhat.com/ubi9'
+    hummingbird-catalog: 'https://images.redhat.com'
+    hummingbird-catalog-docs: 'https://docs.redhat.com/en/documentation/red_hat_hardened_images/1-latest/html/build_and_deploy_secure_minimal_containers_with_red_hat_hardened_images/index'
 
     # Blog references (CVE troubleshooting)
     blog-cve-fix-shipwright: 'https://github.com/tosin2013/sample-quarkus-hummingbird/blob/main/docs/blog/cve-fix-quarkus-openshift-hummingbird-shipwright.md'

--- a/content/antora.yml
+++ b/content/antora.yml
@@ -40,6 +40,10 @@ asciidoc:
     hummingbird-registry: 'registry.access.redhat.com/hi'
     ubi-registry: 'registry.access.redhat.com/ubi9'
 
+    # Blog references (CVE troubleshooting)
+    blog-cve-fix-shipwright: 'https://github.com/tosin2013/sample-quarkus-hummingbird/blob/main/docs/blog/cve-fix-quarkus-openshift-hummingbird-shipwright.md'
+    blog-zero-cve-pipeline: 'https://github.com/tosin2013/sample-quarkus-hummingbird/blob/main/docs/blog/zero-cve-quarkus-hummingbird-pipeline.md'
+
     # Red Hat Trusted Libraries (Tech Preview)
     trusted-libraries-index: 'https://packages.redhat.com/trusted-libraries/python/simple'
     trusted-libraries-docs: 'https://developers.redhat.com/blog/2026/02/27/red-hat-trusted-libraries-trust-and-integrity-your-software-supply-chain'

--- a/content/antora.yml
+++ b/content/antora.yml
@@ -61,6 +61,7 @@ asciidoc:
 
     # ACS (Red Hat Advanced Cluster Security)
     acs-namespace: 'stackrox'
+    acs_password: 'acs-password-injected-by-showroom'
 
     # Placeholders for lab environment (most are injected by showroom)
     # Keys use underscores to match the showroom userdata attribute names

--- a/content/modules/ROOT/pages/module-02-01-buildpacks.adoc
+++ b/content/modules/ROOT/pages/module-02-01-buildpacks.adoc
@@ -404,6 +404,18 @@ Click the security scan result to view the Clair vulnerability report. A Humming
 .Clair security scan: zero CVEs detected in the Hummingbird runtime image
 image::module-02/quay-clair-zero-cve.png[Clair Zero CVE Scan,width=800,link=self,window=blank]
 
+[WARNING]
+====
+*If Quay shows CVEs instead of zero*, the Hummingbird base image itself is rarely the cause. The most common source is transitive Java dependencies bundled inside your application JARs (for example, a networking library pulled in by the framework's Bill of Materials that has not yet been updated to a patched version).
+
+Two blog posts explain exactly why this happens and how to resolve it:
+
+* link:{blog-cve-fix-shipwright}[From CVE alerts to zero vulnerabilities: Quarkus on OpenShift with Hummingbird and Shipwright^] — root-cause analysis and the Maven BOM override technique
+* link:{blog-zero-cve-pipeline}[Zero-CVE Quarkus: automating container security with Hummingbird and GitHub Actions^] — how the automated CI/SBOM pipeline detects and tracks CVEs as GitHub Issues
+
+See the <<cve-override,Optional: Resolving Non-Zero CVEs>> section below for a version-agnostic fix procedure before re-triggering the build.
+====
+
 [[deploy-application]]
 == Deploy Built Image
 
@@ -522,6 +534,131 @@ The image uses `registry.access.redhat.com/hi/openjdk:21-runtime` -- a distroles
 
 NOTE: Standard vulnerability scanners (including Quay/Clair) may not yet fully support Hummingbird's Fedora-based packages. The Hummingbird project provides custom scanning tools (`syft-hummingbird.sh`) for accurate results. See https://gitlab.com/redhat/hummingbird/containers[the Hummingbird repository^] for details.
 ====
+
+[[cve-override]]
+== Optional: Resolving Non-Zero CVEs
+
+If the Quay/Clair scan reports High or Critical CVEs, the Hummingbird base image itself is rarely the cause. The most common source is **transitive Java dependencies** bundled inside your application JARs — libraries pulled in indirectly by the framework's Bill of Materials that have not yet been updated to a patched version.
+
+The steps below work for any library at any version. They do not assume a specific CVE ID or dependency name.
+
+=== Step A: Identify what is actually vulnerable
+
+Scan the built image with Grype, filtering to only findings that have a known fix:
+
+[source,bash,role=execute,subs=attributes]
+----
+grype {quay_hostname}/{quay_user}/sample-quarkus:latest --only-fixed -o json | \
+  jq '.matches[] | {pkg: .artifact.name, version: .artifact.version, fixedIn: .vulnerability.fix.versions[0], severity: .vulnerability.severity}'
+----
+
+.*Example output (package names and versions will vary):*
+----
+{
+  "pkg": "some-library",
+  "version": "A.B.C",
+  "fixedIn": "A.B.D",
+  "severity": "High"
+}
+----
+
+The `fixedIn` field is the target version you need in the final image. Note the `pkg` (artifact name) and `fixedIn` version — you will use them in Step C.
+
+[TIP]
+====
+You can also download the `grype-report` artifact directly from the GitHub Actions CI run on the https://github.com/tosin2013/sample-quarkus-hummingbird/actions[sample-quarkus-hummingbird repository^] if CVEs were flagged there first.
+====
+
+=== Step B: Determine the dependency source
+
+Use Maven's dependency tree to find where the vulnerable package enters the build:
+
+[source,bash,role=execute]
+----
+mvn dependency:tree -Dincludes=<groupId>:<artifactId>
+----
+
+Replace `<groupId>:<artifactId>` with the Maven coordinates of the vulnerable package (for example, `io.netty:netty-codec`).
+
+The output shows whether the package is:
+
+* **Pulled in transitively by the framework BOM** — the most common case; fix with a BOM import override (Step C)
+* **A direct dependency** in your `pom.xml` — fix by bumping the `<version>` directly
+* **Part of the base image** — file an issue with the Hummingbird project; this is rare
+
+=== Step C: Apply the version override
+
+For a framework-managed transitive dependency, import the affected library's own BOM (or add a `<dependencyManagement>` entry) **before** the framework BOM. Maven resolves managed versions using first-match precedence, so the version you declare first wins.
+
+[source,xml]
+----
+<properties>
+  <!-- Set to the "fixedIn" version from Grype output -->
+  <library.version>FIXED-VERSION-FROM-GRYPE</library.version>
+</properties>
+
+<dependencyManagement>
+  <dependencies>
+    <!--
+      If the library publishes its own BOM, import it here — before the framework BOM.
+      This overrides the framework-managed version for all of that library's artifacts.
+    -->
+    <dependency>
+      <groupId>LIBRARY-GROUP-ID</groupId>
+      <artifactId>LIBRARY-BOM-ARTIFACT</artifactId>
+      <version>${library.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+
+    <!-- Framework BOM follows — its transitive version is now overridden above -->
+    <dependency>
+      <groupId>io.quarkus.platform</groupId>
+      <artifactId>quarkus-bom</artifactId>
+      <version>${quarkus.platform.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+----
+
+[NOTE]
+====
+If the library does not publish its own BOM, add an individual `<dependency>` entry with the fixed `<version>` inside `<dependencyManagement>` instead of a BOM import. The first-match rule still applies.
+====
+
+=== Step D: Re-trigger the BuildRun
+
+After committing and pushing the `pom.xml` fix, create a new `BuildRun` to pick up the change:
+
+[source,yaml,role=execute,subs=attributes]
+----
+cat << 'EOF' | oc create -f -
+apiVersion: shipwright.io/v1beta1
+kind: BuildRun
+metadata:
+  name: sample-quarkus-app-run-2
+  namespace: {user}-hummingbird-builds
+spec:
+  build:
+    name: sample-quarkus-app
+EOF
+----
+
+Monitor the new build run:
+
+[source,bash,role=execute,subs=attributes]
+----
+oc get buildrun sample-quarkus-app-run-2 -n {user}-hummingbird-builds -w
+----
+
+Once the build succeeds, return to the Quay console and verify the new image tag shows zero High or Critical CVEs in the Clair scan.
+
+=== Further reading
+
+* link:{blog-cve-fix-shipwright}[From CVE alerts to zero vulnerabilities: Quarkus on OpenShift with Hummingbird and Shipwright^] — a detailed worked example of this exact process, including `mvn dependency:tree` output and the BOM import fix
+* link:{blog-zero-cve-pipeline}[Zero-CVE Quarkus: automating container security with Hummingbird and GitHub Actions^] — how the automated CI/SBOM pipeline in the sample repository detects CVEs and opens GitHub Issues automatically
 
 [[summary]]
 == Summary

--- a/content/modules/ROOT/pages/module-02-01-buildpacks.adoc
+++ b/content/modules/ROOT/pages/module-02-01-buildpacks.adoc
@@ -162,8 +162,8 @@ spec:
     value: "Containerfile"
   - name: build-args
     values:
-    - value: "BUILDER_IMAGE=registry.access.redhat.com/hi/openjdk:21-builder"
-    - value: "RUNTIME_IMAGE=registry.access.redhat.com/hi/openjdk:21-runtime"
+    - value: "BUILDER_IMAGE={hummingbird-registry}/openjdk:21-builder"
+    - value: "RUNTIME_IMAGE={hummingbird-registry}/openjdk:21-runtime"
   output:
     image: {quay_hostname}/{quay_user}/sample-quarkus:latest
     credentials:
@@ -180,8 +180,8 @@ build.shipwright.io/sample-quarkus-app created
 
 * **Source**: Git repository containing a Quarkus REST application with a multi-stage Containerfile
 * **Strategy**: Pre-installed `buildah` ClusterBuildStrategy
-* **Containerfile**: Multi-stage build using `registry.access.redhat.com/hi/openjdk:21-builder` (Stage 1) and `registry.access.redhat.com/hi/openjdk:21-runtime` (Stage 2)
-* **build-args**: Override `BUILDER_IMAGE` and `RUNTIME_IMAGE` to pin the Hummingbird images from `registry.access.redhat.com/hi` (the Red Hat Container Registry)
+* **Containerfile**: Multi-stage build using `{hummingbird-registry}/openjdk:21-builder` (Stage 1) and `{hummingbird-registry}/openjdk:21-runtime` (Stage 2)
+* **build-args**: Override `BUILDER_IMAGE` and `RUNTIME_IMAGE` to pin the Hummingbird images from `{hummingbird-registry}` (the Red Hat Hardened Images registry)
 * **Output**: Push to `{quay_hostname}/{quay_user}/sample-quarkus:latest`
 * **Credentials**: Use `registry-credentials` secret for registry push
 
@@ -189,8 +189,8 @@ build.shipwright.io/sample-quarkus-app created
 ====
 **The Containerfile in the repository follows the same multi-stage pattern from Module 1:**
 
-* **Stage 1 (Builder)**: Uses `registry.access.redhat.com/hi/openjdk:21-builder` which includes JDK 21 and build tools. Maven is installed and used to compile the Quarkus application.
-* **Stage 2 (Runtime)**: Uses `registry.access.redhat.com/hi/openjdk:21-runtime` which is distroless -- no shell, no package manager. Only the compiled JAR and runtime dependencies are copied from Stage 1.
+* **Stage 1 (Builder)**: Uses `{hummingbird-registry}/openjdk:21-builder` which includes JDK 21 and build tools. Maven is installed and used to compile the Quarkus application.
+* **Stage 2 (Runtime)**: Uses `{hummingbird-registry}/openjdk:21-runtime` which is distroless -- no shell, no package manager. Only the compiled JAR and runtime dependencies are copied from Stage 1.
 * The final image runs as **non-root** (UID 65532, the Hummingbird default).
 ====
 
@@ -525,7 +525,7 @@ Look at your container image and check the results of the Quay Security Scanner 
 ====
 **Hummingbird Runtime Advantages:**
 
-The image uses `registry.access.redhat.com/hi/openjdk:21-runtime` -- a distroless image containing only the JRE and essential libraries. Compared to a full `registry.access.redhat.com/ubi9/openjdk-21` image:
+The image uses `{hummingbird-registry}/openjdk:21-runtime` -- a distroless image containing only the JRE and essential libraries. Compared to a full `registry.access.redhat.com/ubi9/openjdk-21` image:
 
 * **Dramatically fewer packages** -- no shell, no package manager, no build tools
 * **Near-zero CVE baseline** -- fewer packages means fewer vulnerabilities
@@ -716,10 +716,10 @@ Looking for additional depth? The following optional sub-modules extend the work
 
 === Additional Resources
 
-*Project Hummingbird:*
-* https://hummingbird-project.io/[Project Hummingbird Official Site^]
+*Red Hat Hardened Images:*
+* {hummingbird-catalog}[Red Hat Hardened Images Catalog^]
+* {hummingbird-catalog-docs}[Red Hat Hardened Images Documentation^]
 * https://gitlab.com/redhat/hummingbird/containers[Hummingbird Containers Repository^]
-* https://quay.io/organization/hummingbird-hatchling[Hummingbird Image Registry^]
 
 *Shipwright Builds:*
 * https://shipwright.io/docs/build/buildstrategies/[BuildStrategy Documentation^]

--- a/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
+++ b/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
@@ -26,7 +26,7 @@ This sub-module introduces a fundamentally different posture. Instead of reactiv
 === What You Will Build
 
 ----
-Phase 1: Deploy legacy Python API (python:3.11-buster)
+Phase 1: Deploy legacy Python API (python:3.11-trixie)
   -> ACS scan reveals fixable CVEs from unused Python packaging tools (pip, setuptools, wheel)
 
 Phase 2: Rebuild with Hummingbird distroless multi-stage
@@ -367,12 +367,12 @@ PYEOF
 
 === Step 2: Write the Legacy Containerfile
 
-This Containerfile uses `python:3.11-buster`, a full Debian-based image packed with OS-level packages the application will never use:
+This Containerfile uses `python:3.11-trixie`, a full Debian-based image packed with OS-level packages the application will never use:
 
 [source,bash,role=execute]
 ----
 cat > Containerfile.legacy << 'EOF'
-FROM quay.io/takinosh/python3.11-buster:latest
+FROM quay.io/takinosh/python3.11-trixie:latest
 WORKDIR /app
 COPY app.py .
 RUN chmod 644 app.py && chown 1001:0 app.py
@@ -453,7 +453,7 @@ Verify the image appears in Quay with its security scan:
 
 image::module-02/legacy-python-quay-tags.png[Quay Repository Tags for legacy-python-api,link=self,window=blank]
 
-Click on the security scan column to view the CVE details. The `python:3.11-buster` base image carries multiple fixable vulnerabilities:
+Click on the security scan column to view the CVE details. The `python:3.11-trixie` base image carries multiple fixable vulnerabilities:
 
 image::module-02/legacy-python-cve-scan.png[Clair Security Scan showing 10 fixable vulnerabilities in legacy-python-api,link=self,window=blank]
 
@@ -768,7 +768,7 @@ Since images were built on-cluster (not locally), we query the registry for size
 ----
 echo "=== Image Size Comparison ==="
 echo ""
-echo "Legacy (python:3.11-buster):"
+echo "Legacy (python:3.11-trixie):"
 skopeo inspect --tls-verify=false \
   --creds="${REGISTRY_USER}:${REGISTRY_PASSWORD}" \
   docker://${WORKSHOP_REGISTRY}/${REGISTRY_USER}/legacy-python-api:vulnerable 2>/dev/null | python3 -c "
@@ -802,7 +802,7 @@ except (json.JSONDecodeError, KeyError):
 ----
 === Image Size Comparison ===
 
-Legacy (python:3.11-buster):
+Legacy (python:3.11-trixie):
   Layers: ~10
   Created: <timestamp>
 
@@ -865,7 +865,7 @@ echo "Total packages in Hummingbird image: $FORTRESS_COUNT"
 
 .*Expected comparison (counts will vary):*
 ----
-Legacy image:      ~430-460 packages (Debian Buster + Python toolchain)
+Legacy image:      ~430-460 packages (Debian Trixie + Python toolchain)
 Hummingbird image: ~50-60 packages (RHEL minimal RPMs — Python runtime only)
 ----
 
@@ -1059,7 +1059,7 @@ image::module-02/acs-fortress-zero-cve.png[ACS Vulnerability Management showing 
 ----
 echo "=== Side-by-Side Comparison ==="
 echo ""
-echo "Legacy (python:3.11-buster):"
+echo "Legacy (python:3.11-trixie):"
 roxctl image scan \
   --image=${WORKSHOP_REGISTRY}/${REGISTRY_USER}/legacy-python-api:vulnerable \
   --insecure-skip-tls-verify \
@@ -1346,7 +1346,7 @@ In case of emergency, add the annotation
 
 [NOTE]
 ====
-Both steps should be blocked. The specific CVEs listed will vary depending on the image scan date, but you should see multiple fixable vulnerabilities from components like `pip`, `setuptools`, `wheel`, and `mercurial` in the `python:3.11-buster` base image.
+Both steps should be blocked. The specific CVEs listed will vary depending on the image scan date, but you should see multiple fixable vulnerabilities from components like `pip`, `setuptools`, `wheel`, and `mercurial` in the `python:3.11-trixie` base image.
 ====
 
 [IMPORTANT]
@@ -1506,7 +1506,7 @@ Congratulations! You have completed Sub-Module 2.2 -- The Immutable Fortress.
 
 .*What You Accomplished*
 {empty} +
-pass:[&#10003;] Deployed a legacy Python API built on `python:3.11-buster` +
+pass:[&#10003;] Deployed a legacy Python API built on `python:3.11-trixie` +
 pass:[&#10003;] Scanned with ACS and observed fixable CVEs from unused Python packaging tools bundled in the base image +
 pass:[&#10003;] Rewrote the application using a Hummingbird distroless multi-stage build +
 pass:[&#10003;] Learned strict JSON exec form for ENTRYPOINT/CMD in shell-less images +

--- a/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
+++ b/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
@@ -624,27 +624,21 @@ You are carrying the security burden of a full OS and packaging toolchain for an
 
 Open the RHACS Central dashboard in your browser.
 
-Click the link:{rhacs_route}[{rhacs_route}^] link to open the RHACS Central dashboard in a separate window.
+Click the https://{rhacs_route}[{rhacs_route}^] link to open the RHACS Central dashboard in a separate window.
 
-Select *openshift-oauth* for the auth provider and click *Log in*.
-
-On the Keycloak login screen use the following credentials, then click *Sign in*:
+Select *Login with username/password* and sign in with the shared workshop admin credentials:
 
 .Username
-[source,bash,role=execute,subs="attributes"]
+[source,bash]
 ----
-{user}
+admin
 ----
 
 .Password
 [source,bash,role=execute,subs="attributes"]
 ----
-{password}
+{acs_password}
 ----
-
-// image::module-02/acs-login.png[ACS Central Login Page,link=self,window=blank]
-
-Allow the requested permissions.
 
 After logging in, you will see the ACS Dashboard showing cluster-wide security metrics -- policy violations, images at most risk, and deployments at most risk:
 

--- a/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
+++ b/content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc
@@ -1103,7 +1103,7 @@ Verify the admission controller configuration via the ACS API:
 [source,bash,role=execute,subs="attributes"]
 ----
 curl -sk -H "Authorization: Bearer {rhacs_api_token}" \
-  "{rhacs_route}/v1/clusters" | python3 acs-check-admission.py
+  "https://{rhacs_route}/v1/clusters" | python3 acs-check-admission.py
 ----
 
 .*Expected output:*
@@ -1130,7 +1130,7 @@ Run the helper script, passing your namespace and policy suffix via environment 
 
 [source,bash,role=execute,subs="attributes"]
 ----
-ACS_ROUTE={rhacs_route}
+ACS_ROUTE=https://{rhacs_route}
 ROX_API_TOKEN={rhacs_api_token}
 export ACS_ROUTE ROX_API_TOKEN
 export LAB_NAMESPACE="{user}-hummingbird-acs-lab"
@@ -1208,7 +1208,7 @@ Policy 2:
 
 [source,bash,role=execute,subs="attributes"]
 ----
-ACS_ROUTE={rhacs_route}
+ACS_ROUTE=https://{rhacs_route}
 
 for POLICY_NAME in "Zero Fixable CVEs Required - {user}" "Image Scan Required - {user}"; do
   POLICY_ID=$(curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" \
@@ -1385,7 +1385,7 @@ Query the policy violations via the ACS REST API:
 
 [source,bash,role=execute,subs="attributes"]
 ----
-ACS_ROUTE={rhacs_route}
+ACS_ROUTE=https://{rhacs_route}
 
 curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" \
   "${ACS_ROUTE}/v1/alerts?query=Namespace:{user}-hummingbird-acs-lab" | \
@@ -1454,7 +1454,7 @@ This is the correct security model. Admission control is a **gate**, not a kill 
 [source,bash,role=execute,subs=attributes]
 ----
 # Example: Create Slack notifier via API
-ACS_ROUTE={rhacs_route}
+ACS_ROUTE=https://{rhacs_route}
 curl -sk -X POST \
   -H "Authorization: Bearer ${ROX_API_TOKEN}" \
   -H "Content-Type: application/json" \
@@ -1484,7 +1484,7 @@ Remove the lab resources when you are finished:
 ----
 oc delete project {user}-hummingbird-acs-lab
 
-ACS_ROUTE={rhacs_route}
+ACS_ROUTE=https://{rhacs_route}
 
 for POLICY_NAME in "Zero Fixable CVEs Required - {user}" "Image Scan Required - {user}"; do
   POLICY_ID=$(curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" \
@@ -1573,7 +1573,7 @@ oc logs -n stackrox deploy/admission-control
 **Issue: Policy not triggering on deployment**
 [source,bash,role=execute,subs="attributes"]
 ----
-ACS_ROUTE={rhacs_route}
+ACS_ROUTE=https://{rhacs_route}
 curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" \
   "${ACS_ROUTE}/v1/policies" | \
   python3 -c "import json,sys; [print(p['name'], p['disabled']) for p in json.load(sys.stdin).get('policies',[]) if 'zero fixable' in p['name'].lower()]"

--- a/runtime-automation/module-02-02/solve.yml
+++ b/runtime-automation/module-02-02/solve.yml
@@ -144,7 +144,7 @@ print(match[0]['id'] if match else '')
         PYEOF
 
         cat > /tmp/acs-legacy-build/Dockerfile << 'EOF'
-        FROM quay.io/takinosh/python3.11-buster:latest
+        FROM quay.io/takinosh/python3.11-trixie:latest
         WORKDIR /app
         COPY app.py .
         RUN chmod 644 app.py && chown 1001:0 app.py

--- a/scripts/mirror-python-trixie.sh
+++ b/scripts/mirror-python-trixie.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Mirror python:3.11-trixie from Docker Hub to quay.io/takinosh
+# Uses an existing podman login session — run `podman login quay.io` first if needed.
+#
+# Usage:
+#   ./scripts/mirror-python-trixie.sh           # interactive
+#   ./scripts/mirror-python-trixie.sh --dry-run # preview only
+
+set -euo pipefail
+
+SOURCE_IMAGE="docker.io/library/python:3.11-trixie"
+DEST_IMAGE="quay.io/takinosh/python3.11-trixie:latest"
+DRY_RUN=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    *) echo "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+echo "=========================================="
+echo "  Mirror python:3.11-trixie → Quay.io"
+echo "=========================================="
+echo ""
+echo "  Source : ${SOURCE_IMAGE}"
+echo "  Dest   : ${DEST_IMAGE}"
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "  Mode   : DRY RUN (no changes will be made)"
+fi
+echo ""
+
+# --- Pre-flight checks ---
+
+if ! command -v podman &>/dev/null; then
+  echo "ERROR: podman is not installed or not on PATH."
+  exit 1
+fi
+
+echo "Checking podman login for quay.io..."
+if ! podman login --get-login quay.io &>/dev/null; then
+  echo "ERROR: Not logged in to quay.io. Run: podman login quay.io"
+  exit 1
+fi
+QUAY_USER=$(podman login --get-login quay.io)
+echo "  Logged in as: ${QUAY_USER}"
+echo ""
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "[dry-run] Would run: podman pull ${SOURCE_IMAGE}"
+  echo "[dry-run] Would run: podman tag  ${SOURCE_IMAGE} ${DEST_IMAGE}"
+  echo "[dry-run] Would run: podman push ${DEST_IMAGE}"
+  echo "[dry-run] Would run: podman manifest inspect ${DEST_IMAGE}"
+  echo ""
+  echo "Dry run complete — no changes made."
+  exit 0
+fi
+
+# --- Pull ---
+
+echo "Pulling ${SOURCE_IMAGE} ..."
+podman pull "${SOURCE_IMAGE}"
+echo ""
+
+# --- Tag ---
+
+echo "Tagging as ${DEST_IMAGE} ..."
+podman tag "${SOURCE_IMAGE}" "${DEST_IMAGE}"
+echo ""
+
+# --- Push ---
+
+echo "Pushing ${DEST_IMAGE} ..."
+podman push "${DEST_IMAGE}"
+echo ""
+
+# --- Verify ---
+
+echo "Verifying push..."
+podman manifest inspect "${DEST_IMAGE}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+digest = data.get('Digest') or data.get('digest', 'n/a')
+print(f'  Digest : {digest}')
+print('  Push verified successfully.')
+" 2>/dev/null || echo "  (manifest inspect returned non-JSON output — image was pushed)"
+echo ""
+
+# --- Optional cleanup ---
+
+read -r -p "Remove local tags for ${SOURCE_IMAGE} and ${DEST_IMAGE}? [y/N] " CLEANUP
+if [[ "${CLEANUP}" =~ ^[Yy]$ ]]; then
+  podman rmi "${DEST_IMAGE}" || true
+  podman rmi "${SOURCE_IMAGE}" || true
+  echo "Local tags removed."
+fi
+
+echo ""
+echo "Done. ${DEST_IMAGE} is available on Quay."

--- a/scripts/setup-workshop-users.sh
+++ b/scripts/setup-workshop-users.sh
@@ -583,6 +583,7 @@ quay_console_url: https://${QUAY_ROUTE:-quay-not-found}
 quay_url: https://${QUAY_ROUTE:-quay-not-found}
 rhacs_route: ${ACS_CENTRAL_ROUTE:-acs-not-available}
 rhacs_api_token: ${USER_ACS_TOKEN:-}
+acs_password: ${ACS_ADMIN_PASS:-acs-password-not-set}
 USERDATA
 
         ${HELM_BIN} template "showroom" "${SHOWROOM_CHART}" \


### PR DESCRIPTION
## Summary

This PR bundles several improvements made since the last sync with upstream:

### 1. ACS UI login and https:// scheme fixes (module-02-07)

- **ACS UI login was broken** — module instructed students to select `openshift-oauth` which was never configured. Replaced with `Login with username/password`, fixed the dashboard link to use `https://`, and introduced `{acs_password}` Showroom attribute so the admin password renders correctly.
- **All ACS API curl commands returned empty output** — `{rhacs_route}` is injected as a bare hostname, so every `curl` was missing `https://`, causing silent failures. Fixed all 6 `ACS_ROUTE=` assignments plus the standalone `/v1/clusters` curl. `ROX_ENDPOINT={rhacs_route}:443` (roxctl) intentionally left as hostname:port.

### 2. Python base image migration to Trixie

- Migrated Python base image from Debian Buster to Trixie in `.github/workflows/mirror-python-images.yml`
- Added `scripts/mirror-python-trixie.sh` migration helper script
- Updated `runtime-automation/module-02-02/solve.yml` to reference Trixie-based image

### 3. Sub-Module 2.1: CVE blog references and optional override fix

- Added a `[WARNING]` admonition at Step 9b (Quay Clair scan verification) linking to two upstream blog posts that explain why non-zero CVEs can appear even with Hummingbird base images (transitive Java dependency CVEs)
- Added a new `[[cve-override]]` optional section with a version-agnostic four-step fix process: Grype scan, `mvn dependency:tree` triage, Maven BOM import override, re-trigger BuildRun
- Blog URL attributes (`blog-cve-fix-shipwright`, `blog-zero-cve-pipeline`) added to `antora.yml`

### 4. Sub-Module 2.1: Hummingbird image reference and link updates

- Replaced hardcoded `registry.access.redhat.com/hi` strings in Build YAML paramValues, prose, NOTE block, and Step 12 with `{hummingbird-registry}` attribute — matching the Module 1 pattern
- Updated Additional Resources: replaced outdated `hummingbird-project.io` and `quay.io/organization/hummingbird-hatchling` links with `{hummingbird-catalog}` (images.redhat.com) and `{hummingbird-catalog-docs}` (official Red Hat docs)
- Added `hummingbird-catalog` and `hummingbird-catalog-docs` attributes to `antora.yml`

## Files Changed

- `content/modules/ROOT/pages/module-02-07-acs-zero-cve.adoc`
- `content/modules/ROOT/pages/module-02-01-buildpacks.adoc`
- `content/antora.yml`
- `scripts/setup-workshop-users.sh`
- `scripts/mirror-python-trixie.sh` (new)
- `.github/workflows/mirror-python-images.yml`
- `runtime-automation/module-02-02/solve.yml`

## Test Plan

- [x] ACS UI login confirmed working with `admin` / Basic auth on live cluster
- [x] All `ACS_ROUTE`-based curl commands verified on live cluster
- [x] CVE WARNING block and `[[cve-override]]` section verified in live Showroom (all 4 user instances)
- [x] `{hummingbird-registry}` attribute renders correctly in Build YAML and prose
- [x] `{hummingbird-catalog}` renders as `https://images.redhat.com` in Additional Resources